### PR TITLE
[BACK] Argument parser minor update

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -94,8 +94,12 @@ Mettre à jour les dépendances:
     tox -vv
 
 ### Lancer le script
+``` bash
+poetry run python back/main.py
 
-    poetry run python back/main.py back/config.yaml
+# Pour charger un config.yaml d'une autre source, utiliser --filename :
+poetry run python back/main.py --filename <path_to_config.yaml>
+```
 
 
 ## License

--- a/back/scripts/utils/argument_parser.py
+++ b/back/scripts/utils/argument_parser.py
@@ -2,8 +2,16 @@ import argparse
 
 class ArgumentParser:
     @staticmethod
-    def parse_args(description):
+    def parse_args(description:str):
         parser = argparse.ArgumentParser(description=description)
-        parser.add_argument('filename')
+
+        # Update parser.add_argument: - Now have a defualt value
+        #                             - The argument --filename is no longer required to execute the script if config.yaml is at the same location than main.py
+        parser.add_argument("--filename",
+                            type = str,
+                            required = False,
+                            default = "./config.yaml",
+                            help = "Chemin vers le fichier de configuration, format yaml")   
+        
         args = parser.parse_args()
         return args


### PR DESCRIPTION
Une simplification de l'argument "filename" qui prend comme valeur par défaut ./config.yaml    .

- Lancer le script ne requiert plus de préciser l'emplacement de config.yaml s'il se trouve à la racine du script.
- Il est possible de charger une autre config en utilisant l'arugment ainsi: --filename <chemin_ver_sconfig.yaml>
- Une docstring help permet de comprendre l'argument à l'appel du script.
- La partie 'Lancer le script' du REAMD.md dans back/ est mise à jour en conséquence.




Msg commit:
- Changed arg filename to --filename
    - --filename no longer required to execute the main.py script (now has ./config.yaml as default value)
    - Added help docstring for the arg

Updated README.md (back/README.md) consequently -> "Lancer le script" chapter