### PR TITLE
[BACK] workflow_manager.py minor update: add age file check for downloaded f…

### DIFF
--- a/back/config.yaml
+++ b/back/config.yaml
@@ -13,26 +13,26 @@ communities:
       Code Insee 2021 Département: str
       Code Insee 2021 Commune: str
     processed_data:
-      path: back/data/communities/processed_data
+      path: data/communities/processed_data
       filename: ofgl_data.csv
 
     epci:
-      file: back/data/communities/scrapped_data/gouv_colloc/epcicom2023.xlsx
+      file: data/communities/scrapped_data/gouv_colloc/epcicom2023.xlsx
       dtype:
         siren: str
         siren_membre: str
-    processed_data_folder: back/data/communities/processed_data/
+    processed_data_folder: data/communities/processed_data/
 
   odf:
     url: https://static.data.gouv.fr/resources/donnees-de-lobservatoire-open-data-des-territoires-edition-2022/20230202-112356/indicateurs-odater-organisations-2022-12-31-.csv
     dtype:
       siren: str
     processed_data:
-      path: back/data/communities/processed_data
+      path: data/communities/processed_data
       filename: odf_data.csv
 
   sirene:
-    path: back/data/communities/
+    path: data/communities/
     filename: scrapped_data/sirene/download_20230413.csv
     columns:
       - "siren"
@@ -101,6 +101,14 @@ datafile_loader:
     - "type"
     - "source"
 
+file_age_to_check:
+  files:
+    odf_data: data/communities/processed_data/odf_data.csv
+    ofgl_data: data/communities/processed_data/ofgl_data.csv
+    sirene_base: data/communities/scrapped_data/sirene/download_20230413.csv
+  age: 365
+
+
 logging:
   version: 1
   formatters:
@@ -116,7 +124,7 @@ logging:
       class: logging.FileHandler
       level: DEBUG
       formatter: simple
-      filename: back/data/logs/log.txt
+      filename: data/logs/log.txt
   root:
     level: DEBUG
     handlers: [console, file]


### PR DESCRIPTION
Update:
workflow_manager.py
> Ajout d'une fonction "check_file_age" dont l'objectif est de log un warning si l'un des fichiers configurés pour ce contrôle dépasse un certains age
> L'intérêt de ce contrôle est d'avertir si des datasets (csv) téléchargés deviennent trop anciens (par défaut 365 jours)


config.yaml
> La configuration des fichiers controlés et de l'age se situe dans config.yml, clé: "file_age_to_check"


Debug:
Les chemins dans config.yaml pointaient encore vers l'arborescence ./back/data/...
Cependant les PR précédentes ont amené à gérer le script en de back/
Voici un exemple de modification apportée pour debug la config :

Avant:
    processed_data:
      path: back/data/communities/processed_data

Maintenant:
    processed_data:
      path: data/communities/processed_data

