### PR TITLE
[BACK] correction config yaml

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -59,9 +59,6 @@ L'intégralité du contenu du dossier ./back/ concerne la partie backend du proj
 ``` bash
 # Copier le repo en local
 git clone https://github.com/dataforgoodfr/13_eclaireur_public.git
-
-# Naviguer sur la partie back du projet
-cd ./13_eclaireur_public/back
 ```
 
 

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -124,7 +124,7 @@ logging:
       class: logging.FileHandler
       level: DEBUG
       formatter: simple
-      filename: data/logs/log.txt
+      filename: back/data/logs/log.txt
   root:
     level: DEBUG
     handlers: [console, file]

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -13,26 +13,26 @@ communities:
       Code Insee 2021 Département: str
       Code Insee 2021 Commune: str
     processed_data:
-      path: data/communities/processed_data
+      path: back/data/communities/processed_data
       filename: ofgl_data.csv
 
     epci:
-      file: data/communities/scrapped_data/gouv_colloc/epcicom2023.xlsx
+      file: back/data/communities/scrapped_data/gouv_colloc/epcicom2023.xlsx
       dtype:
         siren: str
         siren_membre: str
-    processed_data_folder: data/communities/processed_data/
+    processed_data_folder: back/data/communities/processed_data/
 
   odf:
     url: https://static.data.gouv.fr/resources/donnees-de-lobservatoire-open-data-des-territoires-edition-2022/20230202-112356/indicateurs-odater-organisations-2022-12-31-.csv
     dtype:
       siren: str
     processed_data:
-      path: data/communities/processed_data
+      path: back/data/communities/processed_data
       filename: odf_data.csv
 
   sirene:
-    path: data/communities/
+    path: back/data/communities/
     filename: scrapped_data/sirene/download_20230413.csv
     columns:
       - "siren"
@@ -103,9 +103,9 @@ datafile_loader:
 
 file_age_to_check:
   files:
-    odf_data: data/communities/processed_data/odf_data.csv
-    ofgl_data: data/communities/processed_data/ofgl_data.csv
-    sirene_base: data/communities/scrapped_data/sirene/download_20230413.csv
+    odf_data: back/data/communities/processed_data/odf_data.csv
+    ofgl_data: back/data/communities/processed_data/ofgl_data.csv
+    sirene_base: back/data/communities/scrapped_data/sirene/download_20230413.csv
   age: 365
 
 

--- a/back/scripts/utils/argument_parser.py
+++ b/back/scripts/utils/argument_parser.py
@@ -10,7 +10,7 @@ class ArgumentParser:
         parser.add_argument("--filename",
                             type = str,
                             required = False,
-                            default = "./config.yaml",
+                            default = "./back/config.yaml",
                             help = "Chemin vers le fichier de configuration, format yaml")   
         
         args = parser.parse_args()


### PR DESCRIPTION
- Correction config.yaml évitant le soucis de chemins relatifs
- Correctif argument_parser.py : L'arg désignant config.yaml possède un chemin par défaut relatif partant également de la racine du repo.
- Script à lancer depuis racine du projet: ./back/main.py
