### PR TITLE
[BACK] workflow_manager: keep normalized data in memory only when persisting to SQL

### DIFF
--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -37,7 +37,7 @@ class WorkflowManager:
         # Build communities scope, and add selected communities to df_to_save
         communities_selector = self.initialize_communities_scope(df_to_save_to_db)
 
-        # Loop through the topics defined in the config
+        # Loop through the topics defined in the config, e.g. marches publics or subventions.
         for topic, topic_config in self.config["search"].items():
             # Process each topic to get files in scope and datafiles
             topic_files_in_scope, topic_datafiles = self.process_topic(
@@ -53,8 +53,9 @@ class WorkflowManager:
                 getattr(topic_datafiles, "datafiles_out", None),
                 getattr(topic_datafiles, "modifications_data", None),
             )
-            # Add normalized data of the topic to df_to_save
-            df_to_save_to_db[topic + "_normalized"] = topic_datafiles.normalized_data
+            # If config requires it, add normalized data of the topic to df_to_save
+            if self.config["workflow"]["save_to_db"]:
+                df_to_save_to_db[topic + "_normalized"] = topic_datafiles.normalized_data
 
         # Save data to the database if the config allows it
         if self.config["workflow"]["save_to_db"]:

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -87,8 +87,11 @@ class WorkflowManager:
         self.logger.info("Initializing communities scope.")
         # Initialize CommunitiesSelector with the config and select communities
         communities_selector = CommunitiesSelector(self.config["communities"])
+
         # Add selected communities data to df_to_save
-        df_to_save_to_db["communities"] = communities_selector.selected_data
+        if self.config["workflow"]["save_to_db"]:
+            df_to_save_to_db["communities"] = communities_selector.selected_data
+
         self.logger.info("Communities scope initialized.")
         return communities_selector
 


### PR DESCRIPTION
Goal: reduce memory footprint of the script, as devs with 8GB of RAM on their machines are hitting OOM errors (see [Slack](https://data-for-good.slack.com/archives/C08AW9JJ93P/p1739257564258069))

Before: the script keeps all final datasets in memory in order to later save them to SQL, even when saving to SQL is disabled by config.
After: the script keeps final datasets in memory only if saving to SQL is enabled in config.