### PR TITLE
[BACK] Fix CommunitiesSelector data path + refacto

### DIFF
--- a/back/scripts/communities/communities_selector.py
+++ b/back/scripts/communities/communities_selector.py
@@ -44,7 +44,9 @@ class CommunitiesSelector:
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        data_folder = get_project_base_path() / "data" / "communities" / "processed_data"
+        data_folder = (
+            get_project_base_path() / "back" / "data" / "communities" / "processed_data"
+        )
         all_communities_filename = data_folder / "all_communities_data.parquet"
         if all_communities_filename.exists():
             self.all_data = pd.read_parquet(all_communities_filename)

--- a/back/scripts/communities/communities_selector.py
+++ b/back/scripts/communities/communities_selector.py
@@ -6,7 +6,7 @@ import pandas as pd
 from scripts.communities.loaders.odf import OdfLoader
 from scripts.communities.loaders.ofgl import OfglLoader
 from scripts.communities.loaders.sirene import SireneLoader
-from scripts.utils.config import get_project_base_path
+from scripts.utils.config import get_project_data_path
 from scripts.utils.geolocator import GeoLocator
 
 
@@ -44,9 +44,7 @@ class CommunitiesSelector:
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-        data_folder = (
-            get_project_base_path() / "back" / "data" / "communities" / "processed_data"
-        )
+        data_folder = get_project_data_path() / "communities" / "processed_data"
         all_communities_filename = data_folder / "all_communities_data.parquet"
         if all_communities_filename.exists():
             self.all_data = pd.read_parquet(all_communities_filename)

--- a/back/scripts/datasets/datafiles_loader.py
+++ b/back/scripts/datasets/datafiles_loader.py
@@ -1,8 +1,7 @@
 import logging
 import pandas as pd
-from pathlib import Path
 
-from scripts.utils.config import get_project_base_path
+from scripts.utils.config import get_project_data_path
 
 from scripts.loaders.csv_loader import CSVLoader
 from scripts.loaders.excel_loader import ExcelLoader
@@ -133,9 +132,7 @@ class DatafilesLoader:
 
         # Load the schema dictionary to rename the columns
         schema_dict_file = (
-            Path(get_project_base_path())
-            / "back"
-            / "data"
+            get_project_data_path()
             / "datasets"
             / topic
             / "inputs"

--- a/back/scripts/datasets/datagouv_searcher.py
+++ b/back/scripts/datasets/datagouv_searcher.py
@@ -8,7 +8,7 @@ from scripts.loaders.csv_loader import CSVLoader
 from tqdm import tqdm
 
 from back.scripts.loaders.base_loader import retry_session
-from back.scripts.utils.config import get_project_base_path
+from back.scripts.utils.config import get_project_data_path
 
 DATAGOUV_PREFERED_FORMAT = ["csv", "xls", "json", "zip"]
 
@@ -25,7 +25,7 @@ class DataGouvSearcher:
 
         self._config = datagouv_config
         self.scope = communities_selector
-        self.data_folder = get_project_base_path() / "back" / "data" / "datagouv_search"
+        self.data_folder = get_project_data_path() / "datagouv_search"
         self.data_folder.mkdir(parents=True, exist_ok=True)
         (self.data_folder / "organization_datasets").mkdir(parents=True, exist_ok=True)
 

--- a/back/scripts/datasets/single_urls_builder.py
+++ b/back/scripts/datasets/single_urls_builder.py
@@ -1,8 +1,7 @@
 import logging
-from pathlib import Path
 import pandas as pd
 
-from scripts.utils.config import get_project_base_path
+from scripts.utils.config import get_project_data_path
 
 
 class SingleUrlsBuilder:
@@ -18,9 +17,7 @@ class SingleUrlsBuilder:
     # Function to build list of dictionaries of datafiles
     def get_datafiles(self, search_config):
         single_urls_source_file = (
-            Path(get_project_base_path())
-            / "back"
-            / "data"
+            get_project_data_path()
             / "datasets"
             / "subventions"
             / "inputs"

--- a/back/scripts/utils/config.py
+++ b/back/scripts/utils/config.py
@@ -4,3 +4,7 @@ from pathlib import Path
 def get_project_base_path():
     current_directory = Path.cwd()
     return current_directory
+
+
+def get_project_data_path():
+    return get_project_base_path() / "back" / "data"

--- a/back/scripts/utils/geolocator.py
+++ b/back/scripts/utils/geolocator.py
@@ -4,7 +4,7 @@ import requests
 from pathlib import Path
 import pandas as pd
 
-from scripts.utils.config import get_project_base_path
+from scripts.utils.config import get_project_base_path, get_project_data_path
 
 
 class GeoLocator:
@@ -20,14 +20,7 @@ class GeoLocator:
 
     def _get_reg_dep_coords(self) -> pd.DataFrame:
         """Return scrapped data for regions and departements."""
-        data_folder = (
-            Path(get_project_base_path())
-            / "back"
-            / "data"
-            / "communities"
-            / "scrapped_data"
-            / "geoloc"
-        )
+        data_folder = get_project_data_path() / "communities" / "scrapped_data" / "geoloc"
         reg_dep_geoloc_filename = "dep_reg_centers.csv"  # TODO: To add to config
         reg_dep_geoloc_df = pd.read_csv(
             data_folder / reg_dep_geoloc_filename, sep=";"

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -9,7 +9,7 @@ from scripts.datasets.single_urls_builder import SingleUrlsBuilder
 from scripts.datasets.datafiles_loader import DatafilesLoader
 from scripts.datasets.datafile_loader import DatafileLoader
 from scripts.utils.psql_connector import PSQLConnector
-from scripts.utils.config import get_project_base_path
+from scripts.utils.config import get_project_data_path
 from scripts.utils.files_operation import save_csv
 from scripts.utils.constants import (
     FILES_IN_SCOPE_FILENAME,
@@ -136,9 +136,7 @@ class WorkflowManager:
         modifications_data=None,
     ):
         # Define the output folder path
-        output_folder = (
-            Path(get_project_base_path()) / "back" / "data" / "datasets" / topic / "outputs"
-        )
+        output_folder = get_project_data_path() / "datasets" / topic / "outputs"
 
         # Loop through the dataframes (if not None) to save them to the output folder
         if normalized_data is not None:


### PR DESCRIPTION
Depuis la PR https://github.com/dataforgoodfr/13_eclaireur_public/pull/36/, dans `CommunitiesSelector.__init__` on a un path incorrect : 
`get_project_base_path() / "data" / "datagouv_search"`.
Ça pose problème lors de l'exécution du `main.py`. J'ai vu la review mais pas le fix correspondant.

J'en ai profité pour refactoriser en créant `get_project_data_path` pour éviter que cette erreur ne se reproduise.
Si c'est ok pour vous sur le principe, je peux aussi refactoriser le contenu du fichier `config.yaml` et ses appels de façon à pouvoir (ou pas) déplacer ce dossier `data/` sans encombre.