### PR TITLE
[BACK] feat: test sur la structure des config.yaml

### DIFF
--- a/back/tests/config_structure_test.py
+++ b/back/tests/config_structure_test.py
@@ -1,0 +1,47 @@
+from back.scripts.utils.config import get_project_base_path
+from back.scripts.utils.config_manager import ConfigManager
+
+"""
+Tests pour checker la cohérence structurelle entre les fichiers de configuration
+
+Note : il faut pouvoir détecter des anomalies mais rester flexible pour éviter les faux-positifs qui bloqueraient une éventuelle CI
+
+1. Le type des données doit être identique
+2. Des clés de la configuration principale (`main_config_filename`) peuvent être absentes des configurations secondaires (`sub_config_filenames`) mais on considère cependant que toutes les clés des `sub_config_filenames` doivent être présentes dans `main_config_filename`
+"""
+
+main_config_filename = "config.yaml"
+sub_config_filenames = ("config-test.yaml",)
+
+
+def config_structure_test() -> None:
+    def check_keys(main_config: dict, sub_config: dict, path: str) -> None:
+        # Check missing keys
+        diff_keys = set(sub_config) - set(main_config)
+        diff_keys_str = ", ".join(f"{path}.{key}" for key in diff_keys)
+        assert not diff_keys, (
+            f"{sub_config_filename} file keys missing in {main_config_filename} : {diff_keys_str}"
+        )
+
+        # Check type keys
+        for k, sub_config_value in sub_config.items():
+            next_path = f"{path}.{k}"
+            main_config_value = main_config[k]
+            assert type(main_config_value) is type(sub_config_value), (
+                f"Incorrect key type '{next_path}' : {type(main_config_value)} ({main_config_filename}) != {type(sub_config_value)} ({sub_config_filename})"
+            )
+
+            # Recursive check
+            if isinstance(main_config_value, dict):
+                check_keys(main_config_value, sub_config_value, next_path)
+
+    config_folder = get_project_base_path() / "back"
+    main_config = ConfigManager.load_config(config_folder / main_config_filename)
+    path = ""
+    for sub_config_filename in sub_config_filenames:
+        sub_config = ConfigManager.load_config(config_folder / sub_config_filename)
+        check_keys(main_config, sub_config, path)
+
+
+if __name__ == "__main__":
+    config_structure_test()

--- a/tests/back/test_config_structure.py
+++ b/tests/back/test_config_structure.py
@@ -14,7 +14,7 @@ main_config_filename = "config.yaml"
 sub_config_filenames = ("config-test.yaml",)
 
 
-def config_structure_test() -> None:
+def test_config_structure():
     def check_keys(main_config: dict, sub_config: dict, path: str) -> None:
         # Check missing keys
         diff_keys = set(sub_config) - set(main_config)
@@ -41,7 +41,3 @@ def config_structure_test() -> None:
     for sub_config_filename in sub_config_filenames:
         sub_config = ConfigManager.load_config(config_folder / sub_config_filename)
         check_keys(main_config, sub_config, path)
-
-
-if __name__ == "__main__":
-    config_structure_test()


### PR DESCRIPTION
Depuis https://github.com/dataforgoodfr/13_eclaireur_public/pull/57, on sait qu'une simple manipulation dans le fichier config peut tout faire sauter 🧨

Voici un test qui fait quelques vérifications, notamment sur les types des données.

Comme il n'y a pas de structure clairement définie (pas assez stable à l'heure actuelle), on compare et on révèle les différences des fichiers config de façon récursive.

Comme cela n'aurait pas suffit à déceler l'erreur à l'origine de la PR citée plus haut, un check supplémentaire est réalisé pour savoir si des configurations secondaires posséderaient une ou plusieurs clés que n'auraient pas la config de base. On aurait alors remarqué que la clé `testIds` était absente de là où elle aurait dû être (mais pas vu qu'elle était au mauvais endroit).

C'est bien de tester mais qui va exécuter ce test ? Une idée serait à terme de le rajouter dans la CI avant de tester le pipeline.

Le format est-il adapté ? Est-ce suffisamment efficace pour détecter les erreurs et suffisamment flexible pour ne pas bloquer une PR à chaque changement de structure dans le fichier config de base ?
À discuter.