### PR TITLE
[FRONT] Ajout du filtrage par SIREN dans l'API des communautés

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -39,7 +39,7 @@ jobs:
                 GH_HOST: ${{secrets.HOST}}
                 GH_NODE_ENV : ${{secrets.NODE_ENV}}
                 GH_PORT: ${{secrets.PORT}}
-                GH_BASE_URL: ${{ github.event.pull_request.base.repo.name }}-PR-${{ github.event.number }}.cleverapps.io
+                GH_BASE_URL: https://${{ github.event.pull_request.base.repo.name }}-PR-${{ github.event.number }}.cleverapps.io
                 GH_POSTGRESQL_ADDON_HOST: ${{secrets.POSTGRESQL_ADDON_HOST}}
                 GH_POSTGRESQL_ADDON_DB:  ${{secrets.POSTGRESQL_ADDON_DB}}
                 GH_POSTGRESQL_ADDON_USER:  ${{secrets.POSTGRESQL_ADDON_USER}}

--- a/front/app/api/selected_communities/route.ts
+++ b/front/app/api/selected_communities/route.ts
@@ -35,7 +35,6 @@ async function getDataFromPool(options: CommunitiesParamsOptions) {
     values.push(type);
   }
 
-
   if (siren) {
     whereConditions.push(`siren = $${values.length + 1}`);
     values.push(siren);
@@ -48,7 +47,6 @@ async function getDataFromPool(options: CommunitiesParamsOptions) {
   //Ajout de la limite
   query += ' LIMIT $' + (values.length + 1);
   values.push(limit);
-
 
   const { rows } = await client.query(query, values);
   client.release();

--- a/front/app/api/selected_communities/route.ts
+++ b/front/app/api/selected_communities/route.ts
@@ -7,6 +7,7 @@ import { CommunityType } from './types';
 type CommunitiesParamsOptions = {
   type: CommunityType | undefined;
   limit: number;
+  siren?: string;
 };
 
 function mapCommunityType(type: string | null) {
@@ -20,19 +21,34 @@ function mapCommunityType(type: string | null) {
 }
 
 async function getDataFromPool(options: CommunitiesParamsOptions) {
-  const { type, limit } = options;
+  const { type, limit, siren } = options;
   const client = await db.connect();
 
   let query = 'SELECT * FROM selected_communities';
   const values: unknown[] = [];
 
-  query += ' LIMIT $1';
-  values.push(limit);
+  //Construction des conditions WHERE
+  const whereConditions: string[] = [];
 
   if (type) {
-    query += ' WHERE type = $2';
+    whereConditions.push(`type = $${values.length + 1}`);
     values.push(type);
   }
+
+
+  if (siren) {
+    whereConditions.push(`siren = $${values.length + 1}`);
+    values.push(siren);
+  }
+
+  if (whereConditions.length > 0) {
+    query += ' WHERE ' + whereConditions.join(' AND ');
+  }
+
+  //Ajout de la limite
+  query += ' LIMIT $' + (values.length + 1);
+  values.push(limit);
+
 
   const { rows } = await client.query(query, values);
   client.release();
@@ -45,13 +61,19 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const type = mapCommunityType(searchParams.get('type')) ?? undefined;
     const limit = Number(searchParams.get('limit')) ?? undefined;
+    const siren = searchParams.get('siren') ?? undefined;
 
     // Vérification des valeurs
     if (limit < 1 || limit > 5000) {
       return NextResponse.json({ error: 'Limit must be between 1 and 5000' }, { status: 400 });
     }
 
-    const data = await getDataFromPool({ type, limit });
+    // Validation optionnelle du format SIREN
+    if (siren && !/^\d{9}$/.test(siren)) {
+      return NextResponse.json({ error: 'Invalid SIREN format' }, { status: 400 });
+    }
+
+    const data = await getDataFromPool({ type, limit, siren });
 
     return NextResponse.json(data);
   } catch (error) {

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -21,7 +21,7 @@ interface Community {
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
+  const response = await fetch(`https://${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
 
   // Gestion d'erreur basique
   if (!response.ok) {

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -1,3 +1,5 @@
+import db from '@/utils/db';
+
 // Interface pour typer les données de communauté
 interface Community {
   siren: string;
@@ -8,48 +10,43 @@ interface Community {
   latitude: number;
 }
 
-
-
-
-
-
-
-
-
-
+async function getCommunityBySiren(siren: string) {
+  const client = await db.connect();
+  try {
+    const { rows } = await client.query('SELECT * FROM selected_communities WHERE siren = $1', [
+      siren,
+    ]);
+    return rows[0]; // return the first (and only) result since siren is unique
+  } finally {
+    client.release();
+  }
+}
 
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
+  const community = await getCommunityBySiren(siren);
 
-  // Gestion d'erreur basique
-  if (!response.ok) {
-    return <div>Erreur lors de la récupération des données</div>;
+  if (!community) {
+    return <div>Community not found</div>;
   }
-
-  // Conversion de la réponse en JSON
-  const communities: Community[] = await response.json();
-
-  // Vérification si des données ont été trouvées
-  if (communities.length === 0) {
-    return <div>Aucune communauté trouvée avec le SIREN {siren}</div>;
-  }
-
-  // Récupération de la communauté
-  const community = communities[0];
-
   return (
-    <div className="community-page">
-      <h1>{community.nom}</h1>
-
-      <div className="community-details">
-        <p><strong>SIREN:</strong> {community.siren}</p>
-        <p><strong>Type:</strong> {community.type}</p>
-        <p><strong>Population:</strong> {community.population.toLocaleString()} habitants</p>
-        <p><strong>Coordonnées géographiques:</strong> {community.latitude.toFixed(6)}, {community.longitude.toFixed(6)}</p>
+    <div className='community-page'>
+      <div className='community-details'>
+        <h1>{community.nom}</h1>
+        <p>
+          <strong>SIREN:</strong> {community.siren}
+        </p>
+        <p>
+          <strong>Type:</strong> {community.type}
+        </p>
+        <p>
+          <strong>Population:</strong> {community.population}
+        </p>
+        <p>
+          <strong>Location:</strong> ({community.latitude}, {community.longitude})
+        </p>
       </div>
     </div>
-
   );
 }

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -8,20 +8,12 @@ interface Community {
   latitude: number;
 }
 
-
-
-
-
-
-
-
-
-
-
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
+  const response = await fetch(
+    `${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`,
+  );
 
   // Gestion d'erreur basique
   if (!response.ok) {
@@ -40,16 +32,24 @@ export default async function CommunityPage({ params }: { params: Promise<{ sire
   const community = communities[0];
 
   return (
-    <div className="community-page">
+    <div className='community-page'>
       <h1>{community.nom}</h1>
 
-      <div className="community-details">
-        <p><strong>SIREN:</strong> {community.siren}</p>
-        <p><strong>Type:</strong> {community.type}</p>
-        <p><strong>Population:</strong> {community.population.toLocaleString()} habitants</p>
-        <p><strong>Coordonnées géographiques:</strong> {community.latitude.toFixed(6)}, {community.longitude.toFixed(6)}</p>
+      <div className='community-details'>
+        <p>
+          <strong>SIREN:</strong> {community.siren}
+        </p>
+        <p>
+          <strong>Type:</strong> {community.type}
+        </p>
+        <p>
+          <strong>Population:</strong> {community.population.toLocaleString()} habitants
+        </p>
+        <p>
+          <strong>Coordonnées géographiques:</strong> {community.latitude.toFixed(6)},{' '}
+          {community.longitude.toFixed(6)}
+        </p>
       </div>
     </div>
-
   );
 }

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -1,4 +1,6 @@
 // Interface pour typer les données de communauté
+import fetchCommunityBySiren from '@/utils/fetchers/fetchCommunityBySiren';
+
 interface Community {
   siren: string;
   nom: string;
@@ -11,26 +13,7 @@ interface Community {
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const response = await fetch(
-    `${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`,
-  );
-
-  // Gestion d'erreur basique
-  if (!response.ok) {
-    return <div>Erreur lors de la récupération des données</div>;
-  }
-
-  // Conversion de la réponse en JSON
-  const communities: Community[] = await response.json();
-
-  // Vérification si des données ont été trouvées
-  if (communities.length === 0) {
-    return <div>Aucune communauté trouvée avec le SIREN {siren}</div>;
-  }
-
-  // Récupération de la communauté
-  const community = communities[0];
-
+  const community: Community = await fetchCommunityBySiren(siren);
   return (
     <div className='community-page'>
       <h1>{community.nom}</h1>

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -1,4 +1,55 @@
+// Interface pour typer les données de communauté
+interface Community {
+  siren: string;
+  nom: string;
+  type: string;
+  population: number;
+  longitude: number;
+  latitude: number;
+}
+
+
+
+
+
+
+
+
+
+
+
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
-  return <div>Community page for {siren}</div>;
+
+  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
+
+  // Gestion d'erreur basique
+  if (!response.ok) {
+    return <div>Erreur lors de la récupération des données</div>;
+  }
+
+  // Conversion de la réponse en JSON
+  const communities: Community[] = await response.json();
+
+  // Vérification si des données ont été trouvées
+  if (communities.length === 0) {
+    return <div>Aucune communauté trouvée avec le SIREN {siren}</div>;
+  }
+
+  // Récupération de la communauté
+  const community = communities[0];
+
+  return (
+    <div className="community-page">
+      <h1>{community.nom}</h1>
+
+      <div className="community-details">
+        <p><strong>SIREN:</strong> {community.siren}</p>
+        <p><strong>Type:</strong> {community.type}</p>
+        <p><strong>Population:</strong> {community.population.toLocaleString()} habitants</p>
+        <p><strong>Coordonnées géographiques:</strong> {community.latitude.toFixed(6)}, {community.longitude.toFixed(6)}</p>
+      </div>
+    </div>
+
+  );
 }

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -1,5 +1,3 @@
-import db from '@/utils/db';
-
 // Interface pour typer les données de communauté
 interface Community {
   siren: string;
@@ -10,43 +8,48 @@ interface Community {
   latitude: number;
 }
 
-async function getCommunityBySiren(siren: string) {
-  const client = await db.connect();
-  try {
-    const { rows } = await client.query('SELECT * FROM selected_communities WHERE siren = $1', [
-      siren,
-    ]);
-    return rows[0]; // return the first (and only) result since siren is unique
-  } finally {
-    client.release();
-  }
-}
+
+
+
+
+
+
+
+
+
 
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const community = await getCommunityBySiren(siren);
+  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
 
-  if (!community) {
-    return <div>Community not found</div>;
+  // Gestion d'erreur basique
+  if (!response.ok) {
+    return <div>Erreur lors de la récupération des données</div>;
   }
+
+  // Conversion de la réponse en JSON
+  const communities: Community[] = await response.json();
+
+  // Vérification si des données ont été trouvées
+  if (communities.length === 0) {
+    return <div>Aucune communauté trouvée avec le SIREN {siren}</div>;
+  }
+
+  // Récupération de la communauté
+  const community = communities[0];
+
   return (
-    <div className='community-page'>
-      <div className='community-details'>
-        <h1>{community.nom}</h1>
-        <p>
-          <strong>SIREN:</strong> {community.siren}
-        </p>
-        <p>
-          <strong>Type:</strong> {community.type}
-        </p>
-        <p>
-          <strong>Population:</strong> {community.population}
-        </p>
-        <p>
-          <strong>Location:</strong> ({community.latitude}, {community.longitude})
-        </p>
+    <div className="community-page">
+      <h1>{community.nom}</h1>
+
+      <div className="community-details">
+        <p><strong>SIREN:</strong> {community.siren}</p>
+        <p><strong>Type:</strong> {community.type}</p>
+        <p><strong>Population:</strong> {community.population.toLocaleString()} habitants</p>
+        <p><strong>Coordonnées géographiques:</strong> {community.latitude.toFixed(6)}, {community.longitude.toFixed(6)}</p>
       </div>
     </div>
+
   );
 }

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -21,7 +21,7 @@ interface Community {
 export default async function CommunityPage({ params }: { params: Promise<{ siren: string }> }) {
   const siren = (await params).siren;
 
-  const response = await fetch(`https://${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
+  const response = await fetch(`${process.env.BASE_URL}/api/selected_communities?siren=${siren}&limit=1`);
 
   // Gestion d'erreur basique
   if (!response.ok) {

--- a/front/utils/fetchers/fetchCommunities.ts
+++ b/front/utils/fetchers/fetchCommunities.ts
@@ -17,7 +17,6 @@ export async function fetchCommunities(options?: Options) {
   const type = options?.type;
 
   const url = new URL('/api/selected_communities', baseURL);
-
   if (type) url.searchParams.append('type', type);
   url.searchParams.append('limit', limit.toString());
 

--- a/front/utils/fetchers/fetchCommunityBySiren.ts
+++ b/front/utils/fetchers/fetchCommunityBySiren.ts
@@ -1,0 +1,21 @@
+
+export default async function fetchCommunityBySiren(siren: string) {
+    const baseURL = process.env.BASE_URL;
+
+    if (!baseURL) {
+        throw new Error("BASE_URL is not defined in the environment variables.");
+    }
+
+    const url = new URL(`/api/selected_communities?siren=${siren}&limit=1`, baseURL);
+    console.log(url.toString(), 'url'); // Ensure the URL is correctly formatted
+
+    const res = await fetch(url.toString());
+
+    if (!res.ok) {
+        throw new Error(`Failed to fetch community: ${res.status} ${res.statusText}`);
+    }
+
+    const community = await res.json();
+
+    return community[0];
+}


### PR DESCRIPTION
Changements effectués
Cette PR ajoute la possibilité de filtrer les communautés par numéro SIREN dans notre API REST et affiche les détails d'une communauté spécifique.
1. Modifications de l'API (route.ts)

Ajout du paramètre optionnel siren dans les options de filtrage
Mise à jour de la construction des requêtes SQL pour permettre le filtrage par SIREN seul ou combiné avec un type
Amélioration de la génération dynamique des conditions WHERE pour supporter des filtres multiples
Validation du format SIREN (9 chiffres) côté serveur

2. Création de la page de détail d'une communauté

Ajout d'une interface Community qui type correctement les données
Récupération des données de communauté en fonction du SIREN fourni dans les paramètres
Affichage formaté des informations principales (nom, SIREN, type, population, coordonnées)
Gestion des erreurs et cas où aucune communauté n'est trouvée


Cette fonctionnalité permet aux utilisateurs de rechercher et consulter rapidement les informations d'une communauté spécifique en utilisant son identifiant unique SIREN