### PR TITLE
[BACK] feat: revue BaseLoader

### DIFF
--- a/back/scripts/loaders/__init__.py
+++ b/back/scripts/loaders/__init__.py
@@ -7,8 +7,8 @@ from .parquet_loader import *  # noqa
 """
 Dictionary mapping file extensions to their corresponding loader classes.
 """
-LOADER_CLASSES: dict = dict()
-
-for subclass in BaseLoader.__subclasses__():
-    if subclass.file_extensions:
-        LOADER_CLASSES |= dict.fromkeys(subclass.file_extensions, subclass)
+LOADER_CLASSES: dict = {
+    file_extension: subclass
+    for subclass in BaseLoader.__subclasses__()
+    for file_extension in subclass.file_extensions or ()
+}

--- a/back/scripts/loaders/__init__.py
+++ b/back/scripts/loaders/__init__.py
@@ -7,7 +7,7 @@ from .parquet_loader import *  # noqa
 """
 Dictionary mapping file extensions to their corresponding loader classes.
 """
-LOADER_CLASSES: dict = {
+LOADER_CLASSES: dict[str, type[BaseLoader]] = {
     file_extension: subclass
     for subclass in BaseLoader.__subclasses__()
     for file_extension in subclass.file_extensions or ()

--- a/back/scripts/loaders/__init__.py
+++ b/back/scripts/loaders/__init__.py
@@ -1,0 +1,14 @@
+from .base_loader import BaseLoader
+from .csv_loader import *  # noqa
+from .excel_loader import *  # noqa
+from .json_loader import *  # noqa
+from .parquet_loader import *  # noqa
+
+"""
+Dictionary mapping file extensions to their corresponding loader classes.
+"""
+LOADER_CLASSES: dict = dict()
+
+for subclass in BaseLoader.__subclasses__():
+    if subclass.file_extensions:
+        LOADER_CLASSES |= dict.fromkeys(subclass.file_extensions, subclass)

--- a/back/scripts/loaders/base_loader.py
+++ b/back/scripts/loaders/base_loader.py
@@ -1,14 +1,12 @@
 import logging
 import os
 import re
-from typing import Pattern, Self, Type
+from typing import Pattern, Self
 from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-
-LOGGER = logging.getLogger(__name__)
 
 
 def retry_session(retries, session=None, backoff_factor=0.3):
@@ -116,7 +114,7 @@ class BaseLoader:
         return ""
 
     @classmethod
-    def search_loader_class(cls, file_url: str) -> Type | None:
+    def search_loader_class(cls, file_url: str) -> type | None:
         """
         Searches for a loader class based on the file extension and content type.
         """

--- a/back/scripts/loaders/base_loader.py
+++ b/back/scripts/loaders/base_loader.py
@@ -34,7 +34,7 @@ class BaseLoader:
 
     file_extensions: set[str] | None = None
     # http://www.iana.org/assignments/media-types/media-types.xhtml
-    media_type_regex: Pattern[str] | str | None = None
+    file_media_type_regex: Pattern[str] | str | None = None
 
     def __init__(self, file_url, num_retries=3, delay_between_retries=5):
         # file_url : URL of the file to load
@@ -159,10 +159,10 @@ class BaseLoader:
         Check if the given file media type can be loaded by the current loader class.
         """
         can_load = False
-        if cls.media_type_regex and file_media_type:
-            if isinstance(cls.media_type_regex, str):
-                can_load = re.search(cls.media_type_regex, file_media_type)
-            elif isinstance(cls.media_type_regex, re.Pattern):
-                can_load = cls.media_type_regex.search(file_media_type)
+        if cls.file_media_type_regex and file_media_type:
+            if isinstance(cls.file_media_type_regex, str):
+                can_load = re.search(cls.file_media_type_regex, file_media_type)
+            elif isinstance(cls.file_media_type_regex, re.Pattern):
+                can_load = cls.file_media_type_regex.search(file_media_type)
 
         return bool(can_load)

--- a/back/scripts/loaders/base_loader.py
+++ b/back/scripts/loaders/base_loader.py
@@ -38,7 +38,7 @@ class BaseLoader:
     # http://www.iana.org/assignments/media-types/media-types.xhtml
     file_media_type_regex: Pattern[str] | str | None = None
 
-    def __init__(self, file_url, num_retries=3, delay_between_retries=5):
+    def __init__(self, file_url, num_retries=3, delay_between_retries=5, **kwargs):
         # file_url : URL of the file to load
         # num_retries : Number of retries in case of failure
         # delay_between_retries : Delay between retries in seconds
@@ -47,6 +47,7 @@ class BaseLoader:
         self.delay_between_retries = delay_between_retries
         self.logger = logging.getLogger(__name__)
         self.is_url = self.get_file_is_url(self.file_url)
+        self.kwargs = kwargs
 
     def load(self, force: bool = True):
         # FIXME: force == True for retro-compatilibity reasons

--- a/back/scripts/loaders/csv_loader.py
+++ b/back/scripts/loaders/csv_loader.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 class CSVLoader(BaseLoader):
     file_extensions = {"csv"}
-    media_type_regex = re.compile(r"csv", flags=re.IGNORECASE)
+    file_media_type_regex = re.compile(r"csv", flags=re.IGNORECASE)
 
     def __init__(self, file_url, columns_to_keep=None, dtype=None, **kwargs):
         """

--- a/back/scripts/loaders/csv_loader.py
+++ b/back/scripts/loaders/csv_loader.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import re
 from io import StringIO
 
 import pandas as pd
@@ -10,6 +11,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class CSVLoader(BaseLoader):
+    file_extensions = {"csv"}
+    media_type_regex = re.compile(r"csv", flags=re.IGNORECASE)
+
     def __init__(self, file_url, columns_to_keep=None, dtype=None, **kwargs):
         """
         Initialize the CSV loader for either URL or local file.

--- a/back/scripts/loaders/excel_loader.py
+++ b/back/scripts/loaders/excel_loader.py
@@ -14,7 +14,7 @@ class ExcelLoader(BaseLoader):
     """
 
     file_extensions = {"xls", "xlsx", "excel"}
-    media_type_regex = re.compile(r"(excel|spreadsheet|xls|xlsx)", flags=re.IGNORECASE)
+    file_media_type_regex = re.compile(r"(excel|spreadsheet|xls|xlsx)", flags=re.IGNORECASE)
 
     def __init__(self, file_url, dtype=None, columns_to_keep=None, **kwargs):
         super().__init__(file_url, **kwargs)

--- a/back/scripts/loaders/excel_loader.py
+++ b/back/scripts/loaders/excel_loader.py
@@ -1,3 +1,4 @@
+import re
 from io import BytesIO
 
 import pandas as pd
@@ -11,6 +12,9 @@ class ExcelLoader(BaseLoader):
     """
     Loader for Excel files.
     """
+
+    file_extensions = {"xls", "xlsx", "excel"}
+    media_type_regex = re.compile(r"(excel|spreadsheet|xls|xlsx)", flags=re.IGNORECASE)
 
     def __init__(self, file_url, dtype=None, columns_to_keep=None, **kwargs):
         super().__init__(file_url, **kwargs)

--- a/back/scripts/loaders/json_loader.py
+++ b/back/scripts/loaders/json_loader.py
@@ -1,5 +1,6 @@
 import json
-from io import BytesIO
+import re
+from io import BytesIO, StringIO
 
 import pandas as pd
 
@@ -10,6 +11,9 @@ class JSONLoader(BaseLoader):
     """
     Loader for JSON files.
     """
+
+    file_extensions = {"json"}
+    media_type_regex = re.compile(r"json", flags=re.IGNORECASE)
 
     def __init__(self, file_url, key=None, **kwargs):
         super().__init__(file_url, **kwargs)

--- a/back/scripts/loaders/json_loader.py
+++ b/back/scripts/loaders/json_loader.py
@@ -1,6 +1,6 @@
 import json
 import re
-from io import BytesIO, StringIO
+from io import BytesIO
 
 import pandas as pd
 

--- a/back/scripts/loaders/json_loader.py
+++ b/back/scripts/loaders/json_loader.py
@@ -13,7 +13,7 @@ class JSONLoader(BaseLoader):
     """
 
     file_extensions = {"json"}
-    media_type_regex = re.compile(r"json", flags=re.IGNORECASE)
+    file_media_type_regex = re.compile(r"json", flags=re.IGNORECASE)
 
     def __init__(self, file_url, key=None, **kwargs):
         super().__init__(file_url, **kwargs)

--- a/back/scripts/loaders/parquet_loader.py
+++ b/back/scripts/loaders/parquet_loader.py
@@ -11,6 +11,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ParquetLoader(BaseLoader):
+    file_extensions = {"parquet"}
+
     def __init__(self, file_url, columns_to_keep=None, **kwargs):
         super().__init__(file_url, **kwargs)
         self.columns_to_keep = columns_to_keep

--- a/tests/back/loaders/test_base_loader.py
+++ b/tests/back/loaders/test_base_loader.py
@@ -75,6 +75,9 @@ class TestBaseLoader:
         can_load = BaseLoaderFakeNoCsv.can_load_file_media_type("csv")
         assert can_load is False
 
+        can_load = BaseLoaderFakeCsv.can_load_file_media_type("file:///srv/udata/ftype/csv")
+        assert can_load is True
+
         can_load = BaseLoaderFakeJson.can_load_file_media_type("csv")
         assert can_load is False
 

--- a/tests/back/loaders/test_base_loader.py
+++ b/tests/back/loaders/test_base_loader.py
@@ -1,0 +1,149 @@
+import re
+
+import responses
+
+from back.scripts.loaders import BaseLoader as BaseLoaderBase
+
+
+class BaseLoader(BaseLoaderBase):
+    file_extensions = None
+    media_type_regex = None
+
+
+class TestBaseLoader:
+    def test_get_file_is_url(self):
+        is_url = BaseLoader.get_file_is_url("http://example.com")
+        assert is_url is True
+
+        is_url = BaseLoader.get_file_is_url("file://example.com")
+        assert is_url is False
+
+        is_url = BaseLoader.get_file_is_url("/path/to/file.csv")
+        assert is_url is False
+
+    def test_get_file_extension(self):
+        extension = BaseLoader.get_file_extension("file://example.com/file.csv")
+        assert extension == "csv"
+
+        extension = BaseLoader.get_file_extension("/path/to/file.csv")
+        assert extension == "csv"
+
+        extension = BaseLoader.get_file_extension("/path/to/file")
+        assert extension == ""
+
+        extension = BaseLoader.get_file_extension("http://example.com")
+        assert extension == ""
+
+    def test_can_load_file_extension(self):
+        class BaseLoaderFakeCsv(BaseLoader):
+            file_extensions = {"csv"}
+
+        class BaseLoaderFakeNoCsv(BaseLoader):
+            file_extensions = {"no_csv"}
+
+        can_load = BaseLoader.can_load_file_extension("csv")
+        assert can_load is False
+
+        can_load = BaseLoaderFakeCsv.can_load_file_extension("csv")
+        assert can_load is True
+
+        can_load = BaseLoaderFakeNoCsv.can_load_file_extension("csv")
+        assert can_load is False
+
+    def test_can_load_file_media_type(self):
+        class BaseLoaderFakeCsv(BaseLoader):
+            media_type_regex = r"csv"
+
+        class BaseLoaderFakeCsvWithRe(BaseLoader):
+            media_type_regex = re.compile(r"csv")
+
+        class BaseLoaderFakeNoCsv(BaseLoader):
+            media_type_regex = r"no_csv"
+
+        class BaseLoaderFakeJson(BaseLoader):
+            media_type_regex = r"json"
+
+        can_load = BaseLoader.can_load_file_media_type("csv")
+        assert can_load is False
+
+        can_load = BaseLoaderFakeCsv.can_load_file_media_type("csv")
+        assert can_load is True
+
+        can_load = BaseLoaderFakeCsvWithRe.can_load_file_media_type("csv")
+        assert can_load is True
+
+        can_load = BaseLoaderFakeNoCsv.can_load_file_media_type("csv")
+        assert can_load is False
+
+        can_load = BaseLoaderFakeJson.can_load_file_media_type("csv")
+        assert can_load is False
+
+        can_load = BaseLoaderFakeJson.can_load_file_media_type("3gppHalForms+json")
+        assert can_load is True
+
+    @responses.activate
+    def test_get_file_media_type_200(self):
+        file_media_type = BaseLoader.get_file_media_type("file://example.com/file.csv")
+        assert file_media_type == ""
+
+        url = "https://example.com/file.csv"
+        responses.add(
+            responses.HEAD,
+            url,
+            status=200,
+            content_type="text/csv",
+        )
+
+        file_media_type = BaseLoader.get_file_media_type(url)
+        assert file_media_type == "text/csv"
+
+    @responses.activate
+    def test_get_file_media_type_404(self):
+        url = "https://example.com/file.csv"
+        responses.add(
+            responses.HEAD,
+            url,
+            status=404,
+            content_type="text/csv",
+        )
+
+        file_media_type = BaseLoader.get_file_media_type(url)
+        assert file_media_type == ""
+
+    @responses.activate
+    def test_can_load_file(self):
+        class BaseLoaderFakeCsv(BaseLoader):
+            media_type_regex = r"csv"
+
+        class BaseLoaderFakeParquetExtension(BaseLoader):
+            file_extensions = {"parquet"}
+
+        class BaseLoaderFakeNoCsv(BaseLoader):
+            media_type_regex = r"no_csv"
+
+        can_load = BaseLoaderFakeParquetExtension.can_load_file(
+            "back/data/geoloc/dep_reg_centers.parquet"
+        )
+        assert can_load is True
+
+        can_load = BaseLoaderFakeParquetExtension.can_load_file(
+            "back/data/geoloc/dep_reg_centers.json"
+        )
+        assert can_load is False
+
+        url = "https://example.com/file.csv"
+        responses.add(
+            responses.HEAD,
+            url,
+            status=200,
+            content_type="text/csv",
+        )
+
+        can_load = BaseLoader.can_load_file(url)
+        assert can_load is False
+
+        can_load = BaseLoaderFakeCsv.can_load_file(url)
+        assert can_load is True
+
+        can_load = BaseLoaderFakeNoCsv.can_load_file(url)
+        assert can_load is False

--- a/tests/back/loaders/test_base_loader.py
+++ b/tests/back/loaders/test_base_loader.py
@@ -1,5 +1,6 @@
 import re
 
+import pytest
 import responses
 
 from back.scripts.loaders import BaseLoader as BaseLoaderBase
@@ -103,15 +104,10 @@ class TestBaseLoader:
     @responses.activate
     def test_get_file_media_type_404(self):
         url = "https://example.com/file.csv"
-        responses.add(
-            responses.HEAD,
-            url,
-            status=404,
-            content_type="text/csv",
-        )
+        responses.add(responses.HEAD, url, status=404)
 
-        file_media_type = BaseLoader.get_file_media_type(url)
-        assert file_media_type == ""
+        with pytest.raises(RuntimeError):
+            BaseLoader.get_file_media_type(url)
 
     @responses.activate
     def test_can_load_file(self):
@@ -150,3 +146,59 @@ class TestBaseLoader:
 
         can_load = BaseLoaderFakeNoCsv.can_load_file(url)
         assert can_load is False
+
+
+class TestBaseLoaderLoad:
+    @pytest.fixture
+    def loader_file(self):
+        yield BaseLoader("file_url", num_retries=3, delay_between_retries=5)
+
+    @pytest.fixture
+    def loader_url(self):
+        yield BaseLoader("https://example.com/file.csv", num_retries=3, delay_between_retries=5)
+
+    def test_empty_file_url(self, loader_file):
+        loader_file.file_url = ""
+        with pytest.raises(RuntimeError):
+            loader_file.load()
+
+    @responses.activate
+    def test_unsupported_file_url_force(self, loader_url):
+        # TODO: install pytest-mock
+        expected_data = "its working"
+        loader_url.can_load_file = lambda _: False
+        loader_url.process_data = lambda _: expected_data
+
+        responses.add(responses.GET, loader_url.file_url, status=200)
+
+        with pytest.raises(RuntimeError):
+            loader_url.load(force=False)
+        assert loader_url.load(force=True) == expected_data
+
+    def test_local_file_loading(self, loader_file):
+        loader_file._load_from_file = lambda: "data"
+        result = loader_file.load()
+        assert result == "data"
+
+    @responses.activate
+    def test_remote_file_loading_200(self, loader_url):
+        loader_url.process_data = lambda _: "processed_data"
+        responses.add(
+            responses.GET,
+            loader_url.file_url,
+            body="processed_data",
+            status=200,
+        )
+
+        result = loader_url.load()
+        assert result == "processed_data"
+
+    @responses.activate
+    def test_remote_file_loading_non_200(self, loader_url):
+        responses.add(
+            responses.GET,
+            loader_url.file_url,
+            status=404,
+        )
+        with pytest.raises(RuntimeError):
+            loader_url.load()

--- a/tests/back/loaders/test_base_loader.py
+++ b/tests/back/loaders/test_base_loader.py
@@ -7,7 +7,7 @@ from back.scripts.loaders import BaseLoader as BaseLoaderBase
 
 class BaseLoader(BaseLoaderBase):
     file_extensions = None
-    media_type_regex = None
+    file_media_type_regex = None
 
 
 class TestBaseLoader:
@@ -52,16 +52,16 @@ class TestBaseLoader:
 
     def test_can_load_file_media_type(self):
         class BaseLoaderFakeCsv(BaseLoader):
-            media_type_regex = r"csv"
+            file_media_type_regex = r"csv"
 
         class BaseLoaderFakeCsvWithRe(BaseLoader):
-            media_type_regex = re.compile(r"csv")
+            file_media_type_regex = re.compile(r"csv")
 
         class BaseLoaderFakeNoCsv(BaseLoader):
-            media_type_regex = r"no_csv"
+            file_media_type_regex = r"no_csv"
 
         class BaseLoaderFakeJson(BaseLoader):
-            media_type_regex = r"json"
+            file_media_type_regex = r"json"
 
         can_load = BaseLoader.can_load_file_media_type("csv")
         assert can_load is False
@@ -113,13 +113,13 @@ class TestBaseLoader:
     @responses.activate
     def test_can_load_file(self):
         class BaseLoaderFakeCsv(BaseLoader):
-            media_type_regex = r"csv"
+            file_media_type_regex = r"csv"
 
         class BaseLoaderFakeParquetExtension(BaseLoader):
             file_extensions = {"parquet"}
 
         class BaseLoaderFakeNoCsv(BaseLoader):
-            media_type_regex = r"no_csv"
+            file_media_type_regex = r"no_csv"
 
         can_load = BaseLoaderFakeParquetExtension.can_load_file(
             "back/data/geoloc/dep_reg_centers.parquet"

--- a/tests/back/loaders/test_csv_loaders.py
+++ b/tests/back/loaders/test_csv_loaders.py
@@ -101,9 +101,9 @@ class TestCSVLoader:
         responses.add(responses.GET, url, status=404)
 
         loader = CSVLoader(url)
-        df = loader.load()
 
-        assert df is None
+        with pytest.raises(RuntimeError):
+            loader.load()
 
     def test_load_from_file_comma(self, setup_temp_csv_files):
         """Test loading a comma-delimited CSV from a file."""


### PR DESCRIPTION
* ajout des attributs `file_extensions` et `media_type_regex` à `BaseLoader` qui permettent de définir dans chacune des classes enfants, quelles extensions de fichier est attendue (plutôt que faire un gros pâté dans BaseLoader)
  * `media_type_regex` sert pour faire correspondre les content-type des fichiers téléchargés (cette fonctionnalité était mise en place pour les fichiers excel, c'est désormais étendu à toutes les classes par défaut, suffit de la mettre à None pour le désactiver (valeur par défaut))
* split de la méthode `BaseLoader.loader_factory` afin de pouvoir surcharger les méthodes dans chacune des classes, retrait des imports directement dans la méthode
* gestion minimale du status code des requêtes pour déterminer le "content-type" du fichier téléchargé
* `Loader.search_loader_class` renvoie la classe Loader adaptée au fichier/url fourni (sans l'instancier, contrairement à `loader_factory`)
* `can_load_file` permet de savoir si la classe a la possibilité de lire le fichier/url fourni (en fonction des paramètres `file_extensions` et `media_type_regex`, exemple : `JsonLoader.can_load_file("data/plop/file.json")`
  * Cette méthode peut bloquer la méthode `.load()`, l'attribut `force` a été ajouté permettre cela (valeur par défaut : `True` pour des questions de retro-compatibilité), `loader.load(force=False)` permet d'activer cette fonctionnalité
  * Il serait appréciable à terme, de mettre l'attribut `force` à False
* ajout de `back.scripts.loaders.LOADER_CLASSES`, dictionnaire qui associe les extensions de fichier avec le Loader qui lui correspond (de façon presque automatique : il faut compléter le fichier `loaders.__init__` dans le cas où un nouveau fichier viendrait se rajouter)
* ajout des tests des nouvelles méthodes
