### PR TITLE
[BACK] feat: add project_config

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -3,12 +3,19 @@ from scripts.utils.config_manager import ConfigManager
 from scripts.utils.logger_manager import LoggerManager
 from scripts.workflow.workflow_manager import WorkflowManager
 
+from back.scripts.utils.config import project_config
 from back.scripts.workflow.data_warehouse import DataWarehouseWorkflow
 
 if __name__ == "__main__":
     # Parse arguments, load config and configure logger
     args = ArgumentParser.parse_args("Gestionnaire du projet LocalOuvert")
+
+    # Load config file
     config = ConfigManager.load_config(args.filename)
+
+    # Load project configuration instance
+    project_config.load(config)
+
     LoggerManager.configure_logger(config)
 
     workflow_manager = WorkflowManager(args, config)

--- a/back/scripts/utils/config.py
+++ b/back/scripts/utils/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Self
 
 
 def get_project_base_path():
@@ -8,3 +9,37 @@ def get_project_base_path():
 
 def get_project_data_path():
     return get_project_base_path() / "back" / "data"
+
+
+class Config:
+    _instance: Self | None = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self, conf: dict | None):
+        self._locked = False
+        if conf is not None:
+            self.load(conf)
+
+    def __getattr__(self, name):
+        return self.__getitem__(name)
+
+    def __getitem__(self, name):
+        if hasattr(self, "_conf"):
+            return self._conf[name]
+        raise AttributeError("self._conf not found. Did you forget to .load the instance ?")
+
+    def load(self, conf: dict) -> None:
+        if self._locked:
+            raise RuntimeError(
+                "The configuration has already been loaded and can no longer be modified."
+            )
+        self._conf = conf
+        self._locked = True
+
+
+# At this stage, the instance is created without configuration because the conf file has not yet been loaded
+project_config = Config(None)


### PR DESCRIPTION
Parfois on a besoin d'accéder à la configuration du projet comme dans `LoggerManager` ou `DataWarehouseWorkflow`.
Actuellement, on fourni le fichier config à toutes les classes qui en auraient potentiellement besoin. Et parfois, pas de la plus belle des façons.
Le problème c'est que l'on ne sait pas encore quel fichier config va être utilisé lors du chargement des fichiers python.

Cette PR vise à contourner le problème en permettant d'accéder simplement au fichier configuration chargé n'importe où dans le projet une fois le script `main` activé.

```py
from back.scripts.utils.config import project_config

project_config["workflow]["save_to_db"]
# ou 
project_config.workflow["save_to_db"]
```
