### PR TITLE
[BACK] chore: run methods return None

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -14,4 +14,5 @@ if __name__ == "__main__":
     workflow_manager = WorkflowManager(args, config)
     workflow_manager.run_workflow()
 
-    data_warehouse_manager = DataWarehouseWorkflow(config).run()
+    data_warehouse_manager = DataWarehouseWorkflow(config)
+    data_warehouse_manager.run()

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -75,7 +75,6 @@ class DatasetAggregator:
         self._concatenate_files()
         with open(self.data_folder / "errors.json", "w") as f:
             json.dump(self.errors, f)
-        return self
 
     def _process_file(self, file: tuple) -> None:
         """

--- a/back/scripts/datasets/declaration_interet.py
+++ b/back/scripts/datasets/declaration_interet.py
@@ -54,7 +54,7 @@ class DeclaInteretWorkflow:
         self.filename = self.data_folder / "declarations.parquet"
 
     @tracker(ulogger=LOGGER, log_start=True)
-    def run(self):
+    def run(self) -> None:
         self._fetch_xml()
         self._format_to_parquet()
 

--- a/back/scripts/datasets/elected_officials.py
+++ b/back/scripts/datasets/elected_officials.py
@@ -51,14 +51,13 @@ class ElectedOfficialsWorkflow:
         self.data_folder.mkdir(exist_ok=True, parents=True)
 
     @tracker(ulogger=LOGGER, log_start=True)
-    def run(self):
+    def run(self) -> None:
         combined_filename = self.data_folder / "elected_officials.parquet"
         if combined_filename.exists():
             return
         self._fetch_raw_datasets()
         self._combine_datasets()
         self.elected_officials.to_parquet(combined_filename)
-        return self
 
     def _fetch_raw_datasets(self):
         """

--- a/back/scripts/datasets/sirene.py
+++ b/back/scripts/datasets/sirene.py
@@ -43,7 +43,7 @@ class SireneWorkflow:
         self.zip_filename = self.data_folder / "sirene.zip"
 
     @tracker(ulogger=LOGGER, log_start=True)
-    def run(self):
+    def run(self) -> None:
         self._fetch_zip()
         self._format_to_parquet()
 

--- a/back/scripts/workflow/data_warehouse.py
+++ b/back/scripts/workflow/data_warehouse.py
@@ -12,7 +12,7 @@ class DataWarehouseWorkflow:
 
         self.send_to_db = []
 
-    def run(self):
+    def run(self) -> None:
         sirene = pl.read_parquet(
             Path(self._config["sirene"]["data_folder"]) / "sirene.parquet"
         ).drop("raison_sociale_prenom")

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -140,7 +140,8 @@ class WorkflowManager:
 
             topic_agg = TopicAggregator(
                 topic_files_in_scope, topic, topic_config, self.config["datafile_loader"]
-            ).run()
+            )
+            topic_agg.run()
 
             if self.config["workflow"]["save_to_db"]:
                 self.connector.upsert_df_to_sql(


### PR DESCRIPTION
Les méthodes `run` renvoient parfois `None`, parfois `self`. Cela complique le code, sa maintenance et est source d'erreur.
Dans la majorité des cas, le run renvoie `None`, c'est donc ce choix qui a été retenu.

Des exemples de situations que cette PR cherche à simplifier :
```py
    data_warehouse_manager = DataWarehouseWorkflow(config).run()
```
`data_warehouse_manager` vaut None.

```py
        ElectedOfficialsWorkflow(self.config["elected_officials"]["data_folder"]).run()
        SireneWorkflow(self.config["sirene"]).run()
```
`ElectedOfficialsWorkflow.run()` renvoie self
`SireneWorkflow.run()` renvoie None

```py
DatasetAggregator.run()
```
Renvoie self, mais sa signature indique qu'il renvoie None.