### PR TITLE
[BACK] structure Cleaner v1

### DIFF
--- a/back/scripts/datasets/common.py
+++ b/back/scripts/datasets/common.py
@@ -1,5 +1,8 @@
+from functools import cached_property
 from pathlib import Path
 from typing import Type
+
+from back.scripts.loaders import BaseLoader
 
 
 class ProcessorMixin:
@@ -51,6 +54,10 @@ class CleanerMixin(ProcessorMixin):
     @property
     def input_filename(self):
         return self.workflow.fetcher.output_filename
+
+    @cached_property
+    def initial_data(self):
+        return BaseLoader.loader_factory(self.input_filename).load()
 
 
 class CleanerBase(CleanerMixin):
@@ -111,6 +118,10 @@ class WorkflowMixin:
         self.fetcher = None
         self.cleaner = None
         self.updater = None
+
+    @property
+    def config(self) -> dict:
+        return self._config
 
     def run(self) -> None:
         self.fetcher = self.fetcher_class(self)

--- a/back/scripts/datasets/common.py
+++ b/back/scripts/datasets/common.py
@@ -131,4 +131,11 @@ class WorkflowMixin:
         if self.updater_class is not None:
             self.updater = self.updater_class(self)
             self.updater.run()
+            data = self.updater.updated_data
+        else:
+            data = self.cleaner_class.cleaned_data
+        self._send_to_db(data)
+
+    def _send_to_db(self, data) -> None:
         # TODO: save dans un fichier ou push to db en fonction de la config
+        pass

--- a/back/scripts/datasets/common.py
+++ b/back/scripts/datasets/common.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+from typing import Type
+
+
+class ProcessorMixin:
+    def __init__(self, workflow, *args, **kwargs):
+        self.workflow = workflow
+
+    def run(self, *args, **kwargs) -> None:
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    @property
+    def config(self) -> dict:
+        return self.workflow._config
+
+    @property
+    def data_folder(self) -> Path:
+        return self.workflow.data_folder
+
+
+class FetcherMixin(ProcessorMixin):
+    """
+    Équivalent du workflow actuel comme DeclaInteretWorkflow ou MarchesPublicsWorkflow
+    Récupère le fichier (via son url), le reformate et le stocke
+    Si le fichier existe déjà, ne fait rien
+    Le reformatage au sein de cette classe doit être requestionné
+    Géré par l'équipe DE
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.output_filename = ""
+
+
+class FetcherBase(FetcherMixin):
+    pass
+
+
+class CleanerMixin(ProcessorMixin):
+    """
+    Lit le `Fetcher.output_filename` (accessible via `self.input_filename`).
+    Nettoie les données, retire les lignes inutilisables, en doublon etc
+    Les données clean sont sauvegardées dans `self.cleaned_data`
+    Géré par l'équipe DA
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cleaned_data = None
+
+    @property
+    def input_filename(self):
+        return self.workflow.fetcher.output_filename
+
+
+class CleanerBase(CleanerMixin):
+    pass
+
+
+class UpdaterMixin(ProcessorMixin):
+    """
+    Depuis le `Cleaner.cleaned_data` (accessible via self.cleaned_data)
+    Formate la structure du fichier
+    Les données formatée sont sauvegardées dans `self.updated_data`
+    Géré par l'équipe DA
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.updated_data = None
+
+    @property
+    def cleaner(self):
+        return self.workflow.cleaner
+
+    @property
+    def cleaned_data(self):
+        return self.workflow.cleaner.cleaned_data
+
+
+class UpdaterBase(UpdaterMixin):
+    pass
+
+
+"""
+Appelé par le WorkflowManager, le WorkflowMixin est un sous-manager qui gère 3 sous-rôles :
+1. Récupération des données (Fetcher) → actuellement ce sont les classes Workflow (qui devront être renommées), formatage, sauvegarde
+2. Nettoyage des données (Cleaner) → nettoie les données, retire les lignes inutilisables
+3. Mise à jour de la structure des données (Updater) → merge/split des colonnes
+
+Les differents rôles doivent pouvoir être facilement identifiables et contiennent leur propre logique sans interférer avec celle des autres
+L'objectif est de pouvoir intégrer le travail des DA sans avoir à remodeler le travail des DE et inversement
+⇒ Pour cela il faut restructurer un peu et uniformiser le coded
+
+Chaque instance de rôle reçoit l'instance du workflow, qui à court terme, possède les attributs nécessaires (config, instances des autres rôles etc)
+    Cela dans un objectif de faciliter le travail des DA, et de pouvoir identifier par la suite les vrais besoins pour faire le code qui va bien
+Chaque rôle s'active grâce à sa méthode run()
+
+"""
+
+
+class WorkflowMixin:
+    fetcher_class: Type = FetcherBase
+    cleaner_class: Type = CleanerBase
+    updater_class: Type | None = UpdaterBase
+
+    def __init__(self, config: dict, *args, **kwargs):
+        self._config = config
+        self.data_folder = Path(config["data_folder"])
+        self.data_folder.mkdir(exist_ok=True, parents=True)
+        self.fetcher = None
+        self.cleaner = None
+        self.updater = None
+
+    def run(self) -> None:
+        self.fetcher = self.fetcher_class(self)
+        self.fetcher.run()
+        self.cleaner = self.cleaner_class(self)
+        self.cleaner.run()
+        if self.updater_class is not None:
+            self.updater = self.updater_class(self)
+            self.updater.run()
+        # TODO: save dans un fichier ou push to db en fonction de la config

--- a/back/scripts/datasets/communities_financial_accounts.py
+++ b/back/scripts/datasets/communities_financial_accounts.py
@@ -6,15 +6,21 @@ import pandas as pd
 
 from back.scripts.datasets.dataset_aggregator import LOADER_CLASSES, DatasetAggregator
 
+from .common import CleanerBase, UpdaterBase, WorkflowMixin
+
 LOGGER = logging.getLogger(__name__)
 
 
 class FinancialAccounts(DatasetAggregator):
-    def __init__(self, config: dict):
+    def __init__(self, workflow, *args, **kwargs):
+        # TODO: là ça devient vraiment moche donc je propose de créer une méthode `get_files` qui sera appelée dans le super
+        config = workflow.config
         files = pd.read_csv(config["files_csv"], sep=";")
-        super().__init__(files, config)
+        super().__init__(files, workflow, *args, **kwargs)
         self.columns = Counter()
-        self.columns_mapping = pd.read_csv(config["columns_mapping"], sep=";").set_index("name")
+        self.columns_mapping = pd.read_csv(self.config["columns_mapping"], sep=";").set_index(
+            "name"
+        )
 
     def _read_parse_file(self, file_metadata: tuple, raw_filename: Path) -> pd.DataFrame | None:
         loader = LOADER_CLASSES[file_metadata.format](raw_filename)
@@ -24,3 +30,23 @@ class FinancialAccounts(DatasetAggregator):
             v: k for k, v in self.columns_mapping[file_metadata.type].dropna().to_dict().items()
         }
         return df[selected_columns.keys()].rename(columns=selected_columns)
+
+
+class FinancialAccountsCleaner(CleanerBase):
+    def run(self, *args, **kwargs):
+        data = self.initial_data
+        # TODO
+        self.cleaned_data = data
+
+
+class FinancialAccountsUpdater(UpdaterBase):
+    def run(self, *args, **kwargs):
+        data = self.cleaned_data
+        # TODO
+        self.updated_data = data
+
+
+class FinancialAccountsWorkflow(WorkflowMixin):
+    fetcher_class = FinancialAccounts
+    cleaner_class = FinancialAccountsCleaner
+    updater_class = FinancialAccountsUpdater

--- a/back/scripts/datasets/communities_financial_accounts.py
+++ b/back/scripts/datasets/communities_financial_accounts.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from back.scripts.datasets.dataset_aggregator import LOADER_CLASSES, DatasetAggregator
 
-from .common import CleanerBase, UpdaterBase, WorkflowMixin
+from .common import CleanerBase, WorkflowMixin
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,14 +39,6 @@ class FinancialAccountsCleaner(CleanerBase):
         self.cleaned_data = data
 
 
-class FinancialAccountsUpdater(UpdaterBase):
-    def run(self, *args, **kwargs):
-        data = self.cleaned_data
-        # TODO
-        self.updated_data = data
-
-
 class FinancialAccountsWorkflow(WorkflowMixin):
     fetcher_class = FinancialAccounts
     cleaner_class = FinancialAccountsCleaner
-    updater_class = FinancialAccountsUpdater

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -14,6 +14,8 @@ from back.scripts.loaders import LOADER_CLASSES
 from back.scripts.utils.config import get_project_base_path
 from back.scripts.utils.decorators import tracker
 
+from .common import FetcherBase
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -48,16 +50,13 @@ class BaseDatasetAggregator:
     """
 
 
-class DatasetAggregator:
-    def __init__(self, files: pd.DataFrame, config: dict):
-        self._config = config
-
+class DatasetAggregator(FetcherBase):
+    def __init__(self, files: pd.DataFrame, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.files_in_scope = files.assign(url_hash=lambda df: df["url"].apply(_sha256))
 
-        self.data_folder = get_project_base_path() / (config["data_folder"])
-        self.data_folder.mkdir(parents=True, exist_ok=True)
-        self.combined_filename = get_project_base_path() / (config["combined_filename"])
-        self.combined_filename.parent.mkdir(parents=True, exist_ok=True)
+        self.output_filename = get_project_base_path() / self.config["combined_filename"]
+        self.output_filename.parent.mkdir(parents=True, exist_ok=True)
         self.errors = defaultdict(list)
 
     @tracker(ulogger=LOGGER, log_start=True)
@@ -176,13 +175,13 @@ class DatasetAggregator:
         LOGGER.info(f"Concatenating {len(all_files)} files for {str(self)}")
         dfs = [pl.scan_parquet(f) for f in all_files]
         df = pl.concat(dfs, how="diagonal_relaxed")
-        df.sink_parquet(self.combined_filename)
+        df.sink_parquet(self.output_filename)
 
     @property
     def aggregated_dataset(self):
         """
         Property to return the aggregated dataset.
         """
-        if not self.combined_filename.exists():
+        if not self.output_filename.exists():
             raise RuntimeError("Combined file does not exists. You must run .load() first.")
-        return pd.read_parquet(self.combined_filename)
+        return pd.read_parquet(self.output_filename)

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from back.scripts.communities.communities_selector import CommunitiesSelector
-from back.scripts.datasets.communities_financial_accounts import FinancialAccounts
+from back.scripts.datasets.communities_financial_accounts import FinancialAccountsWorkflow
 from back.scripts.datasets.datagouv_catalog import DataGouvCatalog
 from back.scripts.datasets.datagouv_searcher import (
     DataGouvSearcher,
@@ -38,7 +38,7 @@ class WorkflowManager:
         self.logger.info("Workflow started.")
         DataGouvCatalog(self.config["datagouv_catalog"]).run()
         MarchesPublicsWorkflow.from_config(self.config["marches_publics"]).run()
-        FinancialAccounts(self.config["financial_accounts"]).run()
+        FinancialAccountsWorkflow(self.config["financial_accounts"]).run()
         ElectedOfficialsWorkflow(self.config["elected_officials"]["data_folder"]).run()
         SireneWorkflow(self.config["sirene"]).run()
         DeclaInteretWorkflow(self.config["declarations_interet"]).run()


### PR DESCRIPTION
Un début de structure pour les class `Cleaner` et `Updater` basé de ce que j'ai pu voir du code de Chloé (https://github.com/dataforgoodfr/13_eclaireur_public/pull/96) l'idée est de séparer au mieux les logiques.
Idéalement, les DA ne devraient en rien modifier le code des DE mais seulement ajouter leur code en plus. L'inverse est également vrai. J'appelle ça plugger du code, ils sont autonomes.
Ça permet aussi de donner un cadre aux DA avec quelques méthodes basiques pour faciliter leur travail et éviter autant de type de Cleaner que de personnes sur ce projet qui serait un enfer à maintenir et corriger.

Y'a un changement important au lancement du Cleaner qui se base sur le fichier output du workflow plutôt que sur le raw.
1. rien n'oblige à faire les deux à la suite
2. potentiellement le fichier existe et donc il faut à un moment à l'autre l'ouvrir et c'est pas le workflow précédent qui va l'ouvrir au-cas-où pour le Cleaner dont il ignore l'existence

Je veux bien des contres-avis

