### PR TITLE
[BACK] Add template for enrichers + resend data to PSQL

### DIFF
--- a/back/config-test.yaml
+++ b/back/config-test.yaml
@@ -8,7 +8,6 @@ ofgl:
   combined_filename: back/tests/data/ofgl/ofgl.parquet
 
 communities:
-  data_folder: back/tests/data/communities/
   combined_filename: back/tests/data/communities/communities.parquet
   epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
   odf_url: file:./back/scripts/datasets/odf.csv

--- a/back/config-test.yaml
+++ b/back/config-test.yaml
@@ -1,6 +1,6 @@
 workflow:
   save_to_db: True
-  replace_tables: False
+  replace_tables: True
 
 ofgl:
   data_folder: back/tests/data/ofgl

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -125,17 +125,6 @@ outputs_csv:
 warehouse:
   data_folder: back/data/warehouse
 
-
-psql_export:
-  ignore_missing_files: false
-  steps:
-    - all_communities
-    - elected_officials
-    - declarations_interet
-    - financial_accounts
-    - subventions
-    - marches_publics
-
 logging:
   version: 1
   formatters:

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -79,7 +79,7 @@ datagouv_catalog:
   data_folder: back/data/datagouv_catalog
   combined_filename: back/data/datagouv_catalog/catalog.parquet
   catalog_url: null
-  
+
 datafile_loader:
   data_folder: 'back/data/datasets/%(topic)s'
   combined_filename: 'back/data/datasets/%(topic)s.parquet'

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -8,7 +8,6 @@ ofgl:
   combined_filename: back/data/ofgl/ofgl.parquet
 
 communities:
-  data_folder: back/data/communities
   combined_filename: back/data/communities/communities.parquet
   epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
   odf_url: file:./back/scripts/datasets/odf.csv
@@ -125,6 +124,17 @@ outputs_csv:
 
 warehouse:
   data_folder: back/data/warehouse
+
+
+psql_export:
+  ignore_missing_files: false
+  steps:
+    - all_communities
+    - elected_officials
+    - declarations_interet
+    - financial_accounts
+    - subventions
+    - marches_publics
 
 logging:
   version: 1

--- a/back/scripts/communities/communities_selector.py
+++ b/back/scripts/communities/communities_selector.py
@@ -22,12 +22,12 @@ class CommunitiesSelector:
     """
 
     @classmethod
-    def get_config_key() -> str:
+    def get_config_key(cls) -> str:
         return "communities"
 
     @classmethod
     def get_output_path(cls, main_config: dict) -> Path:
-        get_combined_filename(main_config[cls.get_config_key()])
+        return get_combined_filename(main_config, cls.get_config_key())
 
     def __init__(self, main_config):
         self.main_config = main_config

--- a/back/scripts/communities/communities_selector.py
+++ b/back/scripts/communities/communities_selector.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 import pandas as pd
 
+from back.scripts.communities.loaders.ofgl import OfglLoader
 from back.scripts.loaders.base_loader import BaseLoader
-from back.scripts.utils.config import get_project_base_path, project_config
+from back.scripts.utils.config import get_combined_filename, project_config
 from back.scripts.utils.dataframe_operation import IdentifierFormat, normalize_identifiant
 from back.scripts.utils.decorators import tracker
 from back.scripts.utils.geolocator import GeoLocator
@@ -20,13 +21,19 @@ class CommunitiesSelector:
     It merges, cleans, and enriches datasets with geographic coordinates.
     """
 
-    def __init__(self, config):
-        self.config = config
+    @classmethod
+    def get_config_key() -> str:
+        return "communities"
 
-        self.data_folder = get_project_base_path() / config["data_folder"]
-        self.data_folder.mkdir(parents=True, exist_ok=True)
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        get_combined_filename(main_config[cls.get_config_key()])
 
-        self.output_filename = Path(self.config["combined_filename"])
+    def __init__(self, main_config):
+        self.main_config = main_config
+        self.config = main_config[self.get_config_key()]
+
+        self.output_filename = self.get_output_path(main_config)
         self.output_filename.parent.mkdir(parents=True, exist_ok=True)
 
     @tracker(ulogger=LOGGER, log_start=True)
@@ -34,7 +41,7 @@ class CommunitiesSelector:
         if self.output_filename.exists():
             return
         communities = (
-            pd.read_parquet(project_config["ofgl"]["combined_filename"])
+            pd.read_parquet(OfglLoader.get_output_path(self.main_config))
             .drop_duplicates(subset=["siren"], keep="first")
             .drop(columns=["exercice"])
             .fillna({"population": 0})
@@ -42,7 +49,6 @@ class CommunitiesSelector:
             .pipe(self.add_epci_infos)
             .pipe(self.add_sirene_infos)
         )
-
         communities.to_parquet(self.output_filename, index=False)
 
     @tracker(ulogger=LOGGER, log_start=True)

--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -36,12 +36,16 @@ READ_COLUMNS = {
 
 class OfglLoader(DatasetAggregator):
     @classmethod
-    def from_config(cls, config):
-        files = pd.read_csv(config["urls_csv"], sep=";")
-        return cls(files, config)
+    def get_config_key(cls):
+        return "ofgl"
 
-    def __init__(self, files: pd.DataFrame, config: dict):
-        super().__init__(files, config)
+    @classmethod
+    def from_config(cls, main_config):
+        files = pd.read_csv(main_config[cls.get_config_key()]["urls_csv"], sep=";")
+        return cls(files, main_config)
+
+    def __init__(self, files: pd.DataFrame, main_config: dict):
+        super().__init__(files, main_config)
         self.columns = pd.DataFrame()
 
     @tracker(ulogger=LOGGER, inputs=True)

--- a/back/scripts/datasets/communities_financial_accounts.py
+++ b/back/scripts/datasets/communities_financial_accounts.py
@@ -10,9 +10,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class FinancialAccounts(DatasetAggregator):
-    def __init__(self, config: dict):
+    @classmethod
+    def get_config_key(cls) -> str:
+        return "financial_accounts"
+
+    def __init__(self, main_config: dict):
+        config = main_config[self.get_config_key()]
         files = pd.read_csv(config["files_csv"], sep=";")
-        super().__init__(files, config)
+        super().__init__(files, main_config)
         self.columns = Counter()
         self.columns_mapping = pd.read_csv(config["columns_mapping"], sep=";").set_index("name")
 

--- a/back/scripts/datasets/datagouv_catalog.py
+++ b/back/scripts/datasets/datagouv_catalog.py
@@ -23,7 +23,7 @@ class DataGouvCatalog:
         return get_combined_filename(main_config, cls.get_config_key())
 
     def __init__(self, main_config: dict):
-        self._config = main_config[""]
+        self._config = main_config["datagouv_catalog"]
         self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
         self.output_filename = DataGouvCatalog.get_output_path(main_config)

--- a/back/scripts/datasets/datagouv_catalog.py
+++ b/back/scripts/datasets/datagouv_catalog.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 
 from back.scripts.loaders.base_loader import BaseLoader
+from back.scripts.utils.config import get_combined_filename
 from back.scripts.utils.datagouv_api import DataGouvAPI
 from back.scripts.utils.decorators import tracker
 
@@ -13,11 +14,19 @@ LOGGER = logging.getLogger(__name__)
 class DataGouvCatalog:
     DATASET_ID = "5d13a8b6634f41070a43dff3"
 
-    def __init__(self, config: dict):
-        self._config = config
-        self.data_folder = Path(config["data_folder"])
+    @classmethod
+    def get_config_key(cls) -> str:
+        return "datagouv_catalog"
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return get_combined_filename(main_config, cls.get_config_key())
+
+    def __init__(self, main_config: dict):
+        self._config = main_config[""]
+        self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
-        self.output_filename = Path(config["combined_filename"])
+        self.output_filename = DataGouvCatalog.get_output_path(main_config)
         self.output_filename.parent.mkdir(exist_ok=True, parents=True)
 
     @tracker(ulogger=LOGGER, log_start=True)

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -55,14 +55,14 @@ class DatasetAggregator:
     def get_output_path(cls, main_config: dict) -> Path:
         return get_combined_filename(main_config, cls.get_config_key())
 
-    def __init__(self, files: pd.DataFrame, main_config: dict, config_key: str):
-        self._config = main_config[config_key]
+    def __init__(self, files: pd.DataFrame, main_config: dict):
+        self._config = main_config[self.get_config_key()]
 
         self.files_in_scope = files.assign(url_hash=lambda df: df["url"].apply(_sha256))
 
         self.data_folder = get_project_base_path() / self._config["data_folder"]
         self.data_folder.mkdir(parents=True, exist_ok=True)
-        self.output_filename = DatasetAggregator.get_output_path(main_config, config_key)
+        self.output_filename = self.get_output_path(main_config)
         self.output_filename.parent.mkdir(parents=True, exist_ok=True)
         self.errors = defaultdict(list)
 

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -11,7 +11,7 @@ import polars as pl
 from tqdm import tqdm
 
 from back.scripts.loaders import LOADER_CLASSES
-from back.scripts.utils.config import get_project_base_path
+from back.scripts.utils.config import get_combined_filename, get_project_base_path
 from back.scripts.utils.decorators import tracker
 
 LOGGER = logging.getLogger(__name__)
@@ -47,14 +47,22 @@ class DatasetAggregator:
     respectively as "data_folder" and "combined_filename".
     """
 
-    def __init__(self, files: pd.DataFrame, config: dict):
-        self._config = config
+    @classmethod
+    def get_config_key(cls) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return get_combined_filename(main_config, cls.get_config_key())
+
+    def __init__(self, files: pd.DataFrame, main_config: dict, config_key: str):
+        self._config = main_config[config_key]
 
         self.files_in_scope = files.assign(url_hash=lambda df: df["url"].apply(_sha256))
 
-        self.data_folder = get_project_base_path() / config["data_folder"]
+        self.data_folder = get_project_base_path() / self._config["data_folder"]
         self.data_folder.mkdir(parents=True, exist_ok=True)
-        self.output_filename = get_project_base_path() / config["combined_filename"]
+        self.output_filename = DatasetAggregator.get_output_path(main_config, config_key)
         self.output_filename.parent.mkdir(parents=True, exist_ok=True)
         self.errors = defaultdict(list)
 

--- a/back/scripts/datasets/declaration_interet.py
+++ b/back/scripts/datasets/declaration_interet.py
@@ -16,6 +16,7 @@ from back.scripts.utils.beautifulsoup_utils import (
     get_tag_int,
     get_tag_text,
 )
+from back.scripts.utils.config import get_project_base_path
 from back.scripts.utils.decorators import tracker
 
 LOGGER = logging.getLogger(__name__)
@@ -45,13 +46,25 @@ def get_published_bool(tag, exclude=UNPUBLISHED_VALUES) -> bool | None:
 class DeclaInteretWorkflow:
     """https://www.data.gouv.fr/fr/datasets/contenu-des-declarations-publiees-apres-le-1er-juillet-2017-au-format-xml/#/resources"""
 
-    def __init__(self, config: dict):
-        self._config = config
-        self.data_folder = Path(config["data_folder"])
+    @classmethod
+    def get_config_key(cls) -> str:
+        return "declarations_interet"
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return (
+            get_project_base_path()
+            / main_config[cls.get_config_key()]["data_folder"]
+            / "elected_officials.parquet"
+        )
+
+    def __init__(self, main_config: dict):
+        self._config = main_config[self.get_config_key()]
+        self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
 
         self.input_filename = self.data_folder / "declarations.xml"
-        self.output_filename = self.data_folder / "declarations.parquet"
+        self.output_filename = self.get_output_path(main_config)
 
     @tracker(ulogger=LOGGER, log_start=True)
     def run(self) -> None:

--- a/back/scripts/datasets/elected_officials.py
+++ b/back/scripts/datasets/elected_officials.py
@@ -60,7 +60,7 @@ class ElectedOfficialsWorkflow:
         )
 
     def __init__(self, main_config: dict):
-        self._config = main_config[ElectedOfficialsWorkflow.CONFIG_KEY]
+        self._config = main_config[self.get_config_key()]
         self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
         self.output_filename = self.get_output_path(main_config)

--- a/back/scripts/datasets/elected_officials.py
+++ b/back/scripts/datasets/elected_officials.py
@@ -5,6 +5,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from back.scripts.loaders.base_loader import BaseLoader
+from back.scripts.utils.config import get_project_base_path
 from back.scripts.utils.datagouv_api import DataGouvAPI
 from back.scripts.utils.decorators import tracker
 
@@ -46,11 +47,23 @@ RENAME_COMMON_COLUMNS = {
 class ElectedOfficialsWorkflow:
     DATASET_ID = "5c34c4d1634f4173183a64f1"
 
-    def __init__(self, config: dict):
-        self._config = config
-        self.data_folder = Path(config["data_folder"])
+    @classmethod
+    def get_config_key(cls) -> str:
+        return "elected_officials"
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return (
+            get_project_base_path()
+            / main_config[cls.get_config_key()]["data_folder"]
+            / "elected_officials.parquet"
+        )
+
+    def __init__(self, main_config: dict):
+        self._config = main_config[ElectedOfficialsWorkflow.CONFIG_KEY]
+        self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
-        self.output_filename = self.data_folder / "elected_officials.parquet"
+        self.output_filename = self.get_output_path(main_config)
 
     @tracker(ulogger=LOGGER, log_start=True)
     def run(self) -> None:

--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -39,7 +39,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         if config["test_urls"]:
             return cls(
                 pd.DataFrame.from_records([reduce(lambda x, y: x | y, config["test_urls"])]),
-                config,
+                main_config,
             )
 
         catalog = pd.read_parquet(project_config["datagouv_catalog"]["combined_filename"]).pipe(
@@ -62,7 +62,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
 
     def __init__(self, files: pd.DataFrame, config: dict):
         super().__init__(files, config)
-        self._load_schema(config["schema"])
+        self._load_schema(config[self.get_config_key()]["schema"])
 
     def _load_schema(self, url):
         schema_filename = self.data_folder / "official_schema.parquet"

--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -23,7 +23,11 @@ DATASET_ID = "5cd57bf68b4c4179299eb0e9"
 
 class MarchesPublicsWorkflow(DatasetAggregator):
     @classmethod
-    def from_config(cls, config: dict):
+    def get_config_key(cls) -> str:
+        return "marches_publics"
+
+    @classmethod
+    def from_config(cls, main_config: dict):
         """
         Fetch all aggregated datasets regardin public orders.
 
@@ -31,6 +35,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         and files containing only a month.
         We only select the monthly files if the year is not available on a yearly file.
         """
+        config = main_config[cls.get_config_key()]
         if config["test_urls"]:
             return cls(
                 pd.DataFrame.from_records([reduce(lambda x, y: x | y, config["test_urls"])]),
@@ -53,7 +58,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         files = files.rename({"url": "dynamic_url"}).assign(
             url=files["id"].apply(DataGouvAPI.get_stable_file_url)
         )
-        return cls(files, config)
+        return cls(files, main_config)
 
     def __init__(self, files: pd.DataFrame, config: dict):
         super().__init__(files, config)

--- a/back/scripts/datasets/sirene.py
+++ b/back/scripts/datasets/sirene.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import polars as pl
 from polars import col
 
+from back.scripts.utils.config import get_project_base_path
 from back.scripts.utils.decorators import tracker
 
 LOGGER = logging.getLogger(__name__)
@@ -34,13 +35,25 @@ class SireneWorkflow:
     https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/
     """
 
-    def __init__(self, config: dict):
-        self._config = config
+    @classmethod
+    def get_config_key(cls) -> str:
+        return "sirene"
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return (
+            get_project_base_path()
+            / main_config[cls.get_config_key()]["data_folder"]
+            / "sirene.parquet"
+        )
+
+    def __init__(self, main_config: dict):
+        self._config = main_config[self.get_config_key()]
         self.data_folder = Path(self._config["data_folder"])
         self.data_folder.mkdir(exist_ok=True, parents=True)
 
         self.input_filename = self.data_folder / "sirene.zip"
-        self.output_filename = self.data_folder / "sirene.parquet"
+        self.output_filename = self.get_output_path(main_config)
 
     @tracker(ulogger=LOGGER, log_start=True)
     def run(self) -> None:

--- a/back/scripts/datasets/topic_aggregator.py
+++ b/back/scripts/datasets/topic_aggregator.py
@@ -63,6 +63,10 @@ class TopicAggregator(DatasetAggregator):
         self._load_manual_column_rename()
         self.extra_columns = Counter()
 
+    @classmethod
+    def get_output_path(cls, main_config: dict, topic: str) -> Path:
+        return main_config["datafile_loader"]["combined_filename"] % {"topic": str}
+
     def run(self):
         super().run()
         pd.DataFrame.from_dict(self.extra_columns, orient="index").to_csv(

--- a/back/scripts/datasets/topic_aggregator.py
+++ b/back/scripts/datasets/topic_aggregator.py
@@ -57,15 +57,25 @@ class TopicAggregator(DatasetAggregator):
         self.topic = topic
         self.topic_config = topic_config
 
-        super().__init__(files_in_scope, datafile_loader_config)
+        super().__init__(files_in_scope, {"datafile_loader": datafile_loader_config})
 
         self._load_schema(topic_config["schema"])
         self._load_manual_column_rename()
         self.extra_columns = Counter()
 
     @classmethod
+    def get_config_key(cls):
+        return "topic_aggregator"
+
+    @classmethod
     def get_output_path(cls, main_config: dict, topic: str) -> Path:
-        return main_config["datafile_loader"]["combined_filename"] % {"topic": str}
+        # hack until we rename and simplify topic aggregator, as it's always processing subventions
+        return main_config["datafile_loader"]["combined_filename"] % {"topic": topic}
+
+    @classmethod
+    # hack until we rename and simplify topic aggregator, as it's always processing subventions
+    def get_output_path(cls, main_config: dict, topic: str="subventions") -> Path:
+        return main_config["datafile_loader"]["combined_filename"] % {"topic": topic}
 
     def run(self):
         super().run()

--- a/back/scripts/enrichment/base_enricher.py
+++ b/back/scripts/enrichment/base_enricher.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import typing
+
+import pandas as pd
+from back.scripts.utils.config import get_project_base_path
+
+
+class BaseEnricher:
+    """Designed to be subclassed, subclasses must override get_dataset_name and get_input_paths and _clean_and_enrich."""
+
+    @classmethod
+    def get_dataset_name() -> str:
+        raise NotImplementedError("Method must be overriden")
+
+    @classmethod
+    def get_input_paths(cls, _main_config: dict) -> typing.List[Path]:
+        raise NotImplementedError("Method must be overriden")
+
+    @classmethod
+    def _clean_and_enrich(cls, _main_config: dict) -> typing.List[Path]:
+        raise NotImplementedError("Method must be overriden")
+
+    @classmethod
+    def get_output_path(cls, main_config: dict) -> Path:
+        return (
+            get_project_base_path()
+            / main_config["warehouse"]["data_folder"]
+            / f"{cls.get_dataset_name()}.parquet"
+        )
+
+    @classmethod
+    def enrich(cls, main_config: dict) -> None:
+        inputs = map(pd.read_parquet, cls.get_input_paths())
+        output = cls._clean_and_enrich(inputs)
+        output.to_parque(cls.get_output_path(main_config))

--- a/back/scripts/enrichment/base_enricher.py
+++ b/back/scripts/enrichment/base_enricher.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import typing
 
-import pandas as pd
+import polars as pl
 from back.scripts.utils.config import get_project_base_path
 
 
@@ -9,7 +9,7 @@ class BaseEnricher:
     """Designed to be subclassed, subclasses must override get_dataset_name and get_input_paths and _clean_and_enrich."""
 
     @classmethod
-    def get_dataset_name() -> str:
+    def get_dataset_name(cls) -> str:
         raise NotImplementedError("Method must be overriden")
 
     @classmethod
@@ -30,6 +30,6 @@ class BaseEnricher:
 
     @classmethod
     def enrich(cls, main_config: dict) -> None:
-        inputs = map(pd.read_parquet, cls.get_input_paths())
+        inputs = map(pl.read_parquet, cls.get_input_paths(main_config))
         output = cls._clean_and_enrich(inputs)
-        output.to_parque(cls.get_output_path(main_config))
+        output.write_parquet(cls.get_output_path(main_config))

--- a/back/scripts/enrichment/communities_enricher.py
+++ b/back/scripts/enrichment/communities_enricher.py
@@ -7,13 +7,12 @@ from back.scripts.enrichment.base_enricher import BaseEnricher
 
 
 class CommunitiesEnricher(BaseEnricher):
-
     def __init__(self):
         raise Exception("Utility class.")
 
     @classmethod
     def get_dataset_name() -> str:
-       return "communities"
+        return "communities"
 
     @classmethod
     def get_input_paths(cls, main_config: dict):

--- a/back/scripts/enrichment/communities_enricher.py
+++ b/back/scripts/enrichment/communities_enricher.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import typing
+import pandas as pd
+
+from back.scripts.communities.communities_selector import CommunitiesSelector
+from back.scripts.enrichment.base_enricher import BaseEnricher
+
+
+class CommunitiesEnricher(BaseEnricher):
+
+    def __init__(self):
+        raise Exception("Utility class.")
+
+    @classmethod
+    def get_dataset_name() -> str:
+       return "communities"
+
+    @classmethod
+    def get_input_paths(cls, main_config: dict):
+        return [CommunitiesSelector.get_output_path(main_config)]
+
+    @classmethod
+    def _clean_and_enrich(cls, inputs: typing.List[Path]) -> pd.DataFrame:
+        communities, *_ = inputs
+        # Data analysts, please add your code here!
+        return communities

--- a/back/scripts/enrichment/communities_enricher.py
+++ b/back/scripts/enrichment/communities_enricher.py
@@ -11,7 +11,7 @@ class CommunitiesEnricher(BaseEnricher):
         raise Exception("Utility class.")
 
     @classmethod
-    def get_dataset_name() -> str:
+    def get_dataset_name(cls) -> str:
         return "communities"
 
     @classmethod

--- a/back/scripts/enrichment/marches_enricher.py
+++ b/back/scripts/enrichment/marches_enricher.py
@@ -10,7 +10,7 @@ class MarchesPublicsEnricher(BaseEnricher):
         raise Exception("Utility class.")
 
     @classmethod
-    def get_dataset_name() -> str:
+    def get_dataset_name(cls) -> str:
         return "marches_publics"
 
     @classmethod

--- a/back/scripts/enrichment/marches_enricher.py
+++ b/back/scripts/enrichment/marches_enricher.py
@@ -6,13 +6,12 @@ from back.scripts.enrichment.base_enricher import BaseEnricher
 
 
 class MarchesPublicsEnricher(BaseEnricher):
-
     def __init__(self):
         raise Exception("Utility class.")
 
     @classmethod
     def get_dataset_name() -> str:
-       return "marches_publics"
+        return "marches_publics"
 
     @classmethod
     def get_input_paths(cls, main_config: dict):

--- a/back/scripts/enrichment/marches_enricher.py
+++ b/back/scripts/enrichment/marches_enricher.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import typing
+import pandas as pd
+from back.scripts.datasets.marches import MarchesPublicsWorkflow
+from back.scripts.enrichment.base_enricher import BaseEnricher
+
+
+class MarchesPublicsEnricher(BaseEnricher):
+
+    def __init__(self):
+        raise Exception("Utility class.")
+
+    @classmethod
+    def get_dataset_name() -> str:
+       return "marches_publics"
+
+    @classmethod
+    def get_input_paths(cls, main_config: dict):
+        return [MarchesPublicsWorkflow.get_output_path(main_config)]
+
+    @classmethod
+    def _clean_and_enrich(cls, inputs: typing.List[Path]) -> pd.DataFrame:
+        marches, *_ = inputs
+        # Data analysts, please add your code here!
+        return marches

--- a/back/scripts/enrichment/subventions_enricher.py
+++ b/back/scripts/enrichment/subventions_enricher.py
@@ -7,13 +7,18 @@ from back.scripts.enrichment.base_enricher import BaseEnricher
 
 class SubventionsEnricher(BaseEnricher):
     @classmethod
-    def get_dataset_name() -> str:
+    def get_dataset_name(cls) -> str:
         return "subventions"
 
     @classmethod
     def get_input_paths(cls, main_config: dict):
         return [
-            TopicAggregator.get_output_path(main_config, cls.get_dataset_name()),
+            TopicAggregator.get_output_path(
+                TopicAggregator.substitute_config(
+                    "subventions", main_config["datafile_loader"]
+                ),
+                cls.get_dataset_name(),
+            ),
             SireneWorkflow.get_output_path(main_config),
         ]
 
@@ -21,7 +26,7 @@ class SubventionsEnricher(BaseEnricher):
         raise Exception("Utility class.")
 
     @classmethod
-    def _clean_and_enrich(cls, config, inputs):
+    def _clean_and_enrich(cls, inputs):
         """
         Enrich the raw subvention dataset
         """
@@ -61,6 +66,4 @@ class SubventionsEnricher(BaseEnricher):
             )
             .drop("raison_sociale_beneficiaire")
         )
-
-        out_filename = cls.get_output_path(config)
-        subventions.write_parquet(out_filename)
+        return subventions

--- a/back/scripts/enrichment/subventions_enricher.py
+++ b/back/scripts/enrichment/subventions_enricher.py
@@ -1,10 +1,20 @@
 import polars as pl
 from polars import col
 
-class SubventionsEnricher:
+from back.scripts.utils.config import get_project_base_path
 
+
+class SubventionsEnricher:
     def __init__(self):
         raise Exception("Utility class.")
+
+    @staticmethod
+    def get_output_path(main_config: dict) -> str:
+        return (
+            get_project_base_path()
+            / main_config["warehouse"]["data_folder"]
+            / "subventions.parquet"
+        )
 
     @staticmethod
     def enrich_subventions(config, sirene: pl.DataFrame):
@@ -50,5 +60,5 @@ class SubventionsEnricher:
             .drop("raison_sociale_beneficiaire")
         )
 
-        out_filename = config["warehouse"]["data_folder"] / "subventions.parquet"
+        out_filename = SubventionsEnricher.get_output_path(config)
         subventions.write_parquet(out_filename)

--- a/back/scripts/enrichment/subventions_enricher.py
+++ b/back/scripts/enrichment/subventions_enricher.py
@@ -1,0 +1,54 @@
+import polars as pl
+from polars import col
+
+class SubventionsEnricher:
+
+    def __init__(self):
+        raise Exception("Utility class.")
+
+    @staticmethod
+    def enrich_subventions(config, sirene: pl.DataFrame):
+        """
+        Enrich the raw subvention dataset
+        """
+        subventions = (
+            pl.read_parquet(
+                config["datafile_loader"]["combined_filename"] % {"topic": "subventions"}
+            )
+            .with_columns(
+                # Transform idAttribuant from siret to siren.
+                # Data should already be normalized to 15 caracters.
+                col("idAttribuant").str.slice(0, 9).alias("idAttribuant"),
+                col("idBeneficiaire").str.slice(0, 9).alias("idBeneficiaire"),
+            )
+            .join(
+                # Give the official sirene name to the attribuant
+                sirene.select("siren", "raison_sociale"),
+                left_on="idAttribuant",
+                right_on="siren",
+                how="left",
+            )
+            .with_columns(
+                col("raison_sociale").fill_null(col("nomAttribuant")).alias("nomAttribuant")
+            )
+            .drop("raison_sociale")
+            .join(
+                # Give the official sirene name to the beneficiaire
+                sirene.rename(lambda col: col + "_beneficiaire"),
+                left_on="idBeneficiaire",
+                right_on="siren_beneficiaire",
+                how="left",
+            )
+            .with_columns(
+                col("raison_sociale_beneficiaire")
+                .fill_null(col("nomBeneficiaire"))
+                .alias("nomBeneficiaire"),
+                col("raison_sociale_beneficiaire")
+                .is_not_null()
+                .alias("is_valid_siren_beneficiaire"),
+            )
+            .drop("raison_sociale_beneficiaire")
+        )
+
+        out_filename = config["warehouse"]["data_folder"] / "subventions.parquet"
+        subventions.write_parquet(out_filename)

--- a/back/scripts/utils/config.py
+++ b/back/scripts/utils/config.py
@@ -7,6 +7,10 @@ def get_project_base_path():
     return current_directory
 
 
+def get_combined_filename(main_config: dict, config_key: str) -> Path:
+    return get_project_base_path() / main_config[config_key]["combined_filename"]
+
+
 def get_project_data_path():
     return get_project_base_path() / "back" / "data"
 

--- a/back/scripts/workflow/data_warehouse.py
+++ b/back/scripts/workflow/data_warehouse.py
@@ -16,9 +16,9 @@ class DataWarehouseWorkflow:
         self.warehouse_folder.mkdir(exist_ok=True, parents=True)
 
         self.send_to_db = {
-            "all_commnunities": CommunitiesEnricher.get_output_path(),
-            "marches_publics": MarchesPublicsEnricher.get_output_path(),
-            "subventions": SubventionsEnricher.get_output_path(),
+            "all_commnunities": CommunitiesEnricher.get_output_path(config),
+            "marches_publics": MarchesPublicsEnricher.get_output_path(config),
+            "subventions": SubventionsEnricher.get_output_path(config),
         }
 
     def run(self) -> None:
@@ -31,11 +31,6 @@ class DataWarehouseWorkflow:
         if not self._config["workflow"]["save_to_db"]:
             return
         connector = PSQLConnector()
-
-        step = "bla"
-        if step == "subventions_enricher":
-            producer = SubventionsEnricher
-        producer.get_output_path(self._config)
 
         # replace_tables determines wether we should clean
         # the table and reinsert with new schema

--- a/back/scripts/workflow/data_warehouse.py
+++ b/back/scripts/workflow/data_warehouse.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import polars as pl
-from polars import col
 from sqlalchemy import text
 
 from back.scripts.enrichment.subventions_enricher import SubventionsEnricher
@@ -22,13 +21,21 @@ class DataWarehouseWorkflow:
         ).drop("raison_sociale_prenom")
 
         SubventionsEnricher.enrich_subventions(self._config, sirene)
-        self.send_to_db = {"subventions": self.warehouse_folder / "subventions.parquet"}  # temp hack
+        self.send_to_db = {
+            "subventions": self.warehouse_folder / "subventions.parquet"
+        }  # temp hack
         self._send_to_postgres()
 
     def _send_to_postgres(self):
         if not self._config["workflow"]["save_to_db"]:
             return
         connector = PSQLConnector()
+
+        step = "bla"
+        if step == "subventions_enricher":
+            producer = SubventionsEnricher
+        producer.get_output_path(self._config)
+
         # replace_tables determines wether we should clean
         # the table and reinsert with new schema
         # or keep the same schema.
@@ -47,4 +54,3 @@ class DataWarehouseWorkflow:
                         conn.execute(text(f"TRUNCATE {table_name}"))
 
                 df.write_database(table_name, conn, if_table_exists=if_table_exists)
-

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -37,14 +37,14 @@ class WorkflowManager:
 
     def run_workflow(self):
         self.logger.info("Workflow started.")
+        SireneWorkflow(self.config).run()
+        OfglLoader.from_config(self.config).run()
         CommunitiesSelector(self.config).run()
         DataGouvCatalog(self.config).run()
-        DeclaInteretWorkflow(self.config).run()
-        ElectedOfficialsWorkflow(self.config).run()
-        FinancialAccounts(self.config).run()
         MarchesPublicsWorkflow.from_config(self.config).run()
-        OfglLoader.from_config(self.config).run()
-        SireneWorkflow(self.config).run()
+        FinancialAccounts(self.config).run()
+        ElectedOfficialsWorkflow(self.config).run()
+        DeclaInteretWorkflow(self.config).run()
         self._run_subvention_and_marche()
 
         self.logger.info("Workflow completed.")

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -37,14 +37,14 @@ class WorkflowManager:
 
     def run_workflow(self):
         self.logger.info("Workflow started.")
-        SireneWorkflow(self.config["sirene"]).run()
-        OfglLoader.from_config(self.config["ofgl"]).run()
-        CommunitiesSelector(self.config["communities"]).run()
-        DataGouvCatalog(self.config["datagouv_catalog"]).run()
-        MarchesPublicsWorkflow.from_config(self.config["marches_publics"]).run()
-        FinancialAccounts(self.config["financial_accounts"]).run()
-        ElectedOfficialsWorkflow(self.config["elected_officials"]).run()
-        DeclaInteretWorkflow(self.config["declarations_interet"]).run()
+        CommunitiesSelector(self.config).run()
+        DataGouvCatalog(self.config).run()
+        DeclaInteretWorkflow(self.config).run()
+        ElectedOfficialsWorkflow(self.config).run()
+        FinancialAccounts(self.config).run()
+        MarchesPublicsWorkflow.from_config(self.config).run()
+        OfglLoader.from_config(self.config).run()
+        SireneWorkflow(self.config).run()
         self._run_subvention_and_marche()
 
         self.logger.info("Workflow completed.")


### PR DESCRIPTION
* Added a package aiming to contain clean and enrichment code
* Move subventions enrichment into it's own logic
* Send marches and communities to PSQL again
* Each workflow step now specifies it's config key and output path, to make it easier to plug into a previous step, and prepare for a functional template