### PR TITLE
[BACK] Adding heuristics to handle different .json structures

### DIFF
--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -27,6 +27,7 @@ UNNECESSARY_NESTED = [
 COLUMNS_RENAMER = {
     "modalitesExecution": "modaliteExecution",
     "techniques": "technique",
+    "acheteur.id": "acheteur_id",
 }
 
 
@@ -92,8 +93,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         interim_fn = raw_filename.parent / "interim.json"
         if not interim_fn.exists():
             return None
-        out = pd.read_json(interim_fn)
-        out.rename(columns=COLUMNS_RENAMER, inplace=True)
+        out = pd.read_json(interim_fn).rename(columns=COLUMNS_RENAMER)
         object_columns = out.dtypes.pipe(lambda s: s[s == "object"]).index
         corrected = {c: out[c].astype("string").where(out[c].notnull()) for c in object_columns}
         return out.assign(**corrected)

--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -19,6 +19,15 @@ from back.scripts.utils.decorators import tracker
 LOGGER = logging.getLogger(__name__)
 
 DATASET_ID = "5cd57bf68b4c4179299eb0e9"
+UNNECESSARY_NESTED = [
+    "considerationsSociales",
+    "considerationsEnvironnementales",
+    "modalitesExecution",
+]
+COLUMNS_RENAMER = {
+    "modalitesExecution": "modaliteExecution",
+    "techniques": "technique",
+}
 
 
 class MarchesPublicsWorkflow(DatasetAggregator):
@@ -84,6 +93,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         if not interim_fn.exists():
             return None
         out = pd.read_json(interim_fn)
+        out.rename(columns=COLUMNS_RENAMER, inplace=True)
         object_columns = out.dtypes.pipe(lambda s: s[s == "object"]).index
         corrected = {c: out[c].astype("string").where(out[c].notnull()) for c in object_columns}
         return out.assign(**corrected)
@@ -152,13 +162,24 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         if isinstance(titulaires, dict):
             titulaires = [titulaires]
 
+        # titulaire is sometines nested
+        if titulaires[0] is not None and "titulaire" in titulaires[0].keys():
+            titulaires = [titu["titulaire"] for titu in titulaires]
+
+        # acheteur is sometimes just a dictionnary with a single "id" key
         unnested = {}
         for k, v in local_decla.items():
-            if isinstance(v, (list, dict)):
-                v = json.dumps(v)
-            elif isinstance(v, decimal.Decimal):
-                v = float(v)
-            unnested[k] = v
+            if k == "acheteur":
+                try:
+                    unnested[k + ".id"] = str(v["id"])
+                except TypeError:
+                    unnested[k + ".id"] = ""
+            else:
+                if isinstance(v, (list, dict)):
+                    v = json.dumps(v)
+                elif isinstance(v, decimal.Decimal):
+                    v = float(v)
+                unnested[k] = v
         return [{f"titulaire_{k}": v for k, v in t.items()} | unnested for t in titulaires if t]
 
 

--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -174,6 +174,8 @@ class MarchesPublicsWorkflow(DatasetAggregator):
                     unnested[k + ".id"] = str(v["id"])
                 except TypeError:
                     unnested[k + ".id"] = ""
+            elif k == "montant":
+                unnested["montant"] = float(v) / len(titulaires)
             else:
                 if isinstance(v, (list, dict)):
                     v = json.dumps(v)

--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -163,7 +163,7 @@ class MarchesPublicsWorkflow(DatasetAggregator):
             titulaires = [titulaires]
 
         # titulaire is sometines nested
-        if titulaires[0] is not None and "titulaire" in titulaires[0].keys():
+        if len(titulaires) > 0 and "titulaire" in titulaires[0].keys():
             titulaires = [titu["titulaire"] for titu in titulaires]
 
         # acheteur is sometimes just a dictionnary with a single "id" key
@@ -171,9 +171,9 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         for k, v in local_decla.items():
             if k == "acheteur":
                 try:
-                    unnested[k + ".id"] = str(v["id"])
+                    unnested["acheteur.id"] = str(v["id"])
                 except TypeError:
-                    unnested[k + ".id"] = ""
+                    unnested["acheteur.id"] = ""
             elif k == "montant":
                 unnested["montant"] = float(v) / len(titulaires)
             else:

--- a/tests/back/datasets/fixtures/marche_direct.json
+++ b/tests/back/datasets/fixtures/marche_direct.json
@@ -8,11 +8,9 @@
       "montant": 500.0,
       "titulaires": [
         {
-          "titulaire": {
             "typeIdentifiant": "SIRET",
             "id": "id_1"
           }
-        }
       ]
     },
     {
@@ -20,14 +18,16 @@
       "acheteur": {
         "id": "a_02"
       },
-      "montant": 12.78,
+      "montant": 40.0,
       "titulaires": [
         {
-          "titulaire": {
             "typeIdentifiant": "SIRET",
             "id": "id_2"
+          },
+        {
+            "typeIdentifiant": "SIRET",
+            "id": "id_3"
           }
-        }
       ]
     }
   ]

--- a/tests/back/datasets/fixtures/marche_nested.json
+++ b/tests/back/datasets/fixtures/marche_nested.json
@@ -6,7 +6,7 @@
         "acheteur": {
           "id": "a_01"
         },
-        "montant": 500.0,
+        "montant": 200.0,
         "titulaires": [
           {
             "titulaire": {
@@ -21,12 +21,18 @@
         "acheteur": {
           "id": "a_02"
         },
-        "montant": 12.78,
+        "montant": 20,
         "titulaires": [
           {
             "titulaire": {
               "typeIdentifiant": "SIRET",
               "id": "id_2"
+            }
+          },
+          {
+            "titulaire": {
+              "typeIdentifiant": "SIRET",
+              "id": "id_3"
             }
           }
         ]

--- a/tests/back/datasets/test_marches.py
+++ b/tests/back/datasets/test_marches.py
@@ -24,7 +24,7 @@ def test_nested_json_structure():
 
 
 def test_marches_public_dataframes():
-    mp = MarchesPublicsWorkflow.from_config(config["marches_publics"])
+    mp = MarchesPublicsWorkflow.from_config(config)
 
     # Direct marche test
     direct_df = mp._read_parse_file(

--- a/tests/back/datasets/test_marches.py
+++ b/tests/back/datasets/test_marches.py
@@ -1,8 +1,12 @@
 from back.scripts.datasets.marches import MarchesPublicsWorkflow
 from pathlib import Path
-
+from back.scripts.utils.config_manager import ConfigManager
+import os
 
 FIXTURES_DIRECTORY = Path(__file__).parent / "fixtures"
+CONFIG_TEST_FILEPATH = "back/config-test.yaml"
+
+config = ConfigManager.load_config(CONFIG_TEST_FILEPATH)
 
 
 def test_direct_json_structure():
@@ -17,3 +21,29 @@ def test_nested_json_structure():
         MarchesPublicsWorkflow.check_json_structure(FIXTURES_DIRECTORY / "marche_nested.json")
         == "marches.marche"
     )
+
+
+def test_marches_public_dataframes():
+    mp = MarchesPublicsWorkflow.from_config(config["marches_publics"])
+
+    # Direct marche test
+    direct_df = mp._read_parse_file(
+        file_metadata=None, raw_filename=FIXTURES_DIRECTORY / "marche_direct.json"
+    )
+    assert direct_df.shape == (3, 5)
+    assert "acheteur_id" in direct_df.columns
+    assert "titulaire_id" in direct_df.columns
+    assert direct_df["montant"].sum() == 580
+    # Remove the interim.json file created by mp workflow
+    os.remove(FIXTURES_DIRECTORY / "interim.json")
+
+    # Nested marche test
+    nested_df = mp._read_parse_file(
+        file_metadata=None, raw_filename=FIXTURES_DIRECTORY / "marche_nested.json"
+    )
+    assert nested_df.shape == (3, 5)
+    assert "acheteur_id" in nested_df.columns
+    assert "titulaire_id" in nested_df.columns
+    assert nested_df["montant"].sum() == 240
+    # Remove the interim.json file created by mp workflow
+    os.remove(FIXTURES_DIRECTORY / "interim.json")

--- a/tests/back/datasets/test_marches.py
+++ b/tests/back/datasets/test_marches.py
@@ -32,8 +32,10 @@ def test_marches_public_dataframes():
     )
     assert direct_df.shape == (3, 5)
     assert "acheteur_id" in direct_df.columns
+    assert "a_02" in direct_df["acheteur_id"].tolist()
     assert "titulaire_id" in direct_df.columns
-    assert direct_df["montant"].sum() == 580
+    assert "id_3" in direct_df["titulaire_id"].tolist()
+    assert direct_df["montant"].sum() == 540
     # Remove the interim.json file created by mp workflow
     os.remove(FIXTURES_DIRECTORY / "interim.json")
 
@@ -43,7 +45,9 @@ def test_marches_public_dataframes():
     )
     assert nested_df.shape == (3, 5)
     assert "acheteur_id" in nested_df.columns
+    assert "a_02" in nested_df["acheteur_id"].tolist()
     assert "titulaire_id" in nested_df.columns
-    assert nested_df["montant"].sum() == 240
+    assert "id_3" in nested_df["titulaire_id"].tolist()
+    assert nested_df["montant"].sum() == 220
     # Remove the interim.json file created by mp workflow
     os.remove(FIXTURES_DIRECTORY / "interim.json")


### PR DESCRIPTION
Added heuristics to handle different structures in .json marches publics
- Cases where "titulaires" are nested
- Cases where "acheteur" is a dict contaning "id" (being either str or int) vs when "acheteur.id" is a field 
- -> returning systematically "acheteur.id" as a string
- Identifying columns that are unnecessarilly nested (only contains a single declaration with similar header). Not used so far