### PR TITLE
[BACK] Corrige les doubles colonnes population

### DIFF
--- a/back/config-test.yaml
+++ b/back/config-test.yaml
@@ -8,6 +8,7 @@ ofgl:
   combined_filename: back/tests/data/ofgl/ofgl.parquet
 
 communities:
+  data_folder: back/tests/data/communities
   combined_filename: back/tests/data/communities/communities.parquet
   epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
   odf_url: file:./back/scripts/datasets/odf.csv
@@ -21,7 +22,6 @@ communities:
       filename: cities_to_geolocate.csv
 
   geo_metrics_dataset_id: "6745d9ae4524d845d2138193"
-  postal_code_dataset_id: "545b55e1c751df52de9b6045"
 
 cpv_labels:
   combined_filename:  back/data/cpv_labels/cpv_labels.parquet

--- a/back/config-test.yaml
+++ b/back/config-test.yaml
@@ -20,13 +20,8 @@ communities:
       path: back/tests/data/geolocator/
       filename: cities_to_geolocate.csv
 
-  geo_metrics:
-    dataset_id: "6745d9ae4524d845d2138193"
-    data_folder: back/data/communities/scrapped_data/geo_metrics
-
-  postal_code:
-    dataset_id: "545b55e1c751df52de9b6045"
-    data_folder: back/data/communities/scrapped_data/postal_code
+  geo_metrics_dataset_id: "6745d9ae4524d845d2138193"
+  postal_code_dataset_id: "545b55e1c751df52de9b6045"
 
 cpv_labels:
   combined_filename:  back/data/cpv_labels/cpv_labels.parquet

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -22,7 +22,6 @@ communities:
       filename: cities_to_geolocate.csv
 
   geo_metrics_dataset_id: "6745d9ae4524d845d2138193"
-  postal_code_dataset_id: "545b55e1c751df52de9b6045"
 
 
 datagouv_search:

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -8,9 +8,10 @@ ofgl:
   combined_filename: back/data/ofgl/ofgl.parquet
 
 communities:
+  data_folder: back/data/communities
   combined_filename: back/data/communities/communities.parquet
   epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
-  odf_url: file:./back/scripts/datasets/odf.csv
+  odf_url: file:back/scripts/datasets/odf.csv
 
   geolocator:
     epci_coords_scrapped_data_file: back/data/communities/scrapped_data/geoloc/epci_geolocs.csv
@@ -20,13 +21,8 @@ communities:
       path: back/data/communities/processed_data
       filename: cities_to_geolocate.csv
 
-  geo_metrics:
-    dataset_id: "6745d9ae4524d845d2138193"
-    data_folder: back/data/communities/scrapped_data/geo_metrics
-
-  postal_code:
-    dataset_id: "545b55e1c751df52de9b6045"
-    data_folder: back/data/communities/scrapped_data/postal_code
+  geo_metrics_dataset_id: "6745d9ae4524d845d2138193"
+  postal_code_dataset_id: "545b55e1c751df52de9b6045"
 
 
 datagouv_search:

--- a/back/scripts/communities/communities_selector.py
+++ b/back/scripts/communities/communities_selector.py
@@ -56,7 +56,7 @@ class CommunitiesSelector:
             .pipe(self.add_epci_infos)
             .pipe(self.add_geocoordinates)
             .pipe(self.add_sirene_infos)
-            .pipe(self.add_geo_metrics)
+            .pipe(self.add_geo_and_postal_metrics)
             .pipe(normalize_column_names)
         )
         communities.to_parquet(self.output_filename, index=False)
@@ -101,9 +101,9 @@ class CommunitiesSelector:
         )
 
     @tracker(ulogger=LOGGER, log_start=True)
-    def add_geo_metrics(self, frame: pd.DataFrame) -> pd.DataFrame:
+    def add_geo_and_postal_metrics(self, frame: pd.DataFrame) -> pd.DataFrame:
         """
-        Adds area (superficie) and density information to the communities DataFrame by fetching
+        Adds area (superficie), density and postal code to the communities DataFrame by fetching
         the latest version from data.gouv.fr using the dataset_id.
         """
         geo_metrics_filename = self.data_folder / "geo_metrics.parquet"


### PR DESCRIPTION
Limite les colonnes ajoutées par code_postal et geo metrics au minimum demandé. Evite d'avoir deux fois la colonne population.