### PR TITLE
[FRONT] feature: add fetchers and kpis for total communities count and subventions

### DIFF
--- a/front/components/ProjectDescription.tsx
+++ b/front/components/ProjectDescription.tsx
@@ -1,9 +1,17 @@
 import Link from 'next/link';
 
-import { Description } from '@radix-ui/react-dialog';
+import { fetchCommunitiesTotalCount } from '@/utils/fetchers/kpis/fetchCommunitiesTotalCount';
+import { fetchPublishedSubventionsTotal } from '@/utils/fetchers/kpis/fetchPublishedSubventionsTotal';
+import { fetchSubventionsTotalBudget } from '@/utils/fetchers/kpis/fetchSubventionsTotalBudget';
 import { ArrowRight } from 'lucide-react';
 
-export default function ProjectDescription() {
+const KPIS_YEAR = 2023;
+
+export default async function ProjectDescription() {
+  const communitiesTotalCount = await fetchCommunitiesTotalCount();
+  const publishedSubventionsTotal = await fetchPublishedSubventionsTotal(KPIS_YEAR);
+  const subventionsTotalBudget = await fetchSubventionsTotalBudget(KPIS_YEAR);
+
   return (
     <div className='px-20 py-16'>
       <h2 className='mb-5 text-3xl font-bold uppercase'>Le projet</h2>
@@ -40,7 +48,10 @@ export default function ProjectDescription() {
         </div>
         <div className='grid grid-cols-1 justify-items-center gap-4 xl:grid-cols-2 2xl:px-20'>
           <ChiffreCle value='0%' description='Des dépenses françaises sont publiées' />
-          <ChiffreCle value='XXX' description='Collectivités recensées sur le site' />
+          <ChiffreCle
+            value={communitiesTotalCount}
+            description='Collectivités recensées sur le site'
+          />
           <ChiffreCle value='XMd€' description='Budget national des collectivités' />
           <ChiffreCle value='XXX' description='XXX' />
         </div>
@@ -50,7 +61,7 @@ export default function ProjectDescription() {
 }
 
 type ChiffreCleProps = {
-  value: string;
+  value: string | number;
   description: string;
 };
 

--- a/front/components/ProjectDescription.tsx
+++ b/front/components/ProjectDescription.tsx
@@ -52,7 +52,7 @@ export default async function ProjectDescription() {
             value={communitiesTotalCount}
             description='Collectivités recensées sur le site'
           />
-          <ChiffreCle value='XMd€' description='Budget national des collectivités' />
+          <ChiffreCle value='XMd€' description='Budget total des collectivités' />
           <ChiffreCle value='XXX' description='XXX' />
         </div>
       </div>

--- a/front/utils/fetchers/constants.ts
+++ b/front/utils/fetchers/constants.ts
@@ -4,6 +4,7 @@ export enum DataTable {
   MarchesPublicsStaging = 'staging_marches_public',
   CommunitiesTest = 'selected_communitiestest_indices',
   Communities = 'collectivites',
+  CommunitiesAccount = 'comptes_collectivites',
   Subventions = 'subventions',
   MarchesPublics = 'marches_publics',
 }

--- a/front/utils/fetchers/kpis/fetchCommunitiesTotalCount.ts
+++ b/front/utils/fetchers/kpis/fetchCommunitiesTotalCount.ts
@@ -1,0 +1,22 @@
+import { getQueryFromPool } from '@/utils/db';
+
+import { DataTable } from '../constants';
+
+const TABLE_NAME = DataTable.Communities;
+
+export function createSQLQueryParams(): [string, (string | number)[]] {
+  const querySQL = `
+    SELECT COUNT(DISTINCT c.siren)
+    FROM ${TABLE_NAME} AS c
+  `;
+
+  return [querySQL, []];
+}
+
+export async function fetchCommunitiesTotalCount(): Promise<number> {
+  const params = createSQLQueryParams();
+
+  const result = (await getQueryFromPool(...params)) as { count: number }[];
+
+  return result[0].count;
+}

--- a/front/utils/fetchers/kpis/fetchPublishedSubventionsTotal.ts
+++ b/front/utils/fetchers/kpis/fetchPublishedSubventionsTotal.ts
@@ -1,0 +1,31 @@
+import { getQueryFromPool } from '@/utils/db';
+
+import { DataTable } from '../constants';
+
+const TABLE_NAME = DataTable.Subventions;
+const JOINED_TABLE_NAME = DataTable.Communities;
+
+export function createSQLQueryParams(year: number): [string, (string | number)[]] {
+  const values = [year];
+  const querySQL = `
+    SELECT SUM(subvention.montant) 
+    FROM ${TABLE_NAME} AS subvention
+    INNER JOIN ${JOINED_TABLE_NAME} AS community ON community.siren = subvention.id_attribuant
+    WHERE subvention.annee = $1
+  `;
+
+  return [querySQL, values];
+}
+
+/**
+ * Montant total subventions déclarées de manière exploitable
+ * @param year
+ * @returns
+ */
+export async function fetchPublishedSubventionsTotal(year: number): Promise<number> {
+  const params = createSQLQueryParams(year);
+
+  const result = (await getQueryFromPool(...params)) as { sum: number }[];
+
+  return result[0].sum;
+}

--- a/front/utils/fetchers/kpis/fetchPusblishedMarchesPublicsTotal.ts
+++ b/front/utils/fetchers/kpis/fetchPusblishedMarchesPublicsTotal.ts
@@ -1,0 +1,41 @@
+import { getQueryFromPool } from '@/utils/db';
+
+import { DataTable } from '../constants';
+
+const MP_TABLE = DataTable.MarchesPublics;
+const COMMUNITIES_TABLE = DataTable.Communities;
+
+// TODO - change dateNotification to annee_notification when db updated
+// Still bug on dateNotification
+export function createSQLQueryParams(year: number): [string, (string | number)[]] {
+  const values = [year];
+  const querySQL = `
+    WITH mp_siren AS (
+        SELECT 
+            LEFT(acheteur_id,9) AS acheteur_siren,
+            montant,
+        FROM ${MP_TABLE} mp
+        WHERE DATE_PART('year', dateNotification::date) = $1
+    )
+    SELECT SUM(mps.montant)
+    FROM mp_siren AS mps
+    INNER JOIN ${COMMUNITIES_TABLE} c
+    ON mps.acheteur_siren = c.siren
+  `;
+
+  return [querySQL, values];
+}
+
+/**
+ * Montant total marchés publics déclarés
+ * En ne gardant que les marchés publics inferieur a 1Md
+ * @param year
+ * @returns
+ */
+export async function fetchPusblishedMarchesPublicsTotal(year: number): Promise<number> {
+  const params = createSQLQueryParams(year);
+
+  const result = (await getQueryFromPool(...params)) as { sum: number }[];
+
+  return result[0].sum;
+}

--- a/front/utils/fetchers/kpis/fetchSubventionsTotalBudget.ts
+++ b/front/utils/fetchers/kpis/fetchSubventionsTotalBudget.ts
@@ -1,0 +1,29 @@
+import { getQueryFromPool } from '@/utils/db';
+
+import { DataTable } from '../constants';
+
+const TABLE_NAME = DataTable.CommunitiesAccount;
+
+export function createSQLQueryParams(year: number): [string, (string | number)[]] {
+  const values = [year];
+  const querySQL = `
+    SELECT SUM(subventions)
+    FROM ${TABLE_NAME}
+    WHERE LEFT(exercice, 4) = $1
+  `;
+
+  return [querySQL, values];
+}
+
+/**
+ * Montant total subventions dans budget
+ * @param year
+ * @returns
+ */
+export async function fetchSubventionsTotalBudget(year: number): Promise<number> {
+  const params = createSQLQueryParams(year);
+
+  const result = (await getQueryFromPool(...params)) as { sum: number }[];
+
+  return result[0].sum;
+}


### PR DESCRIPTION
PR pour les requetes qui etaient possible defaire avec les tables actuelles dans le back ! (donc Nombre de collectivités étudiées Montant total subventions déclarées de manière exploitable, Montant total subventions dans budget) la partie MP, les clefs ne sont pas encore en snake_case