### PR TITLE
[FRONT] : Fix : FAQ footer word changed + Homepage collectivités number as integer

### DIFF
--- a/front/app/(a-propos)/faq/page.tsx
+++ b/front/app/(a-propos)/faq/page.tsx
@@ -155,7 +155,7 @@ export default function Page() {
           <AccordionTrigger>Où puis-je télécharger les données utilisées ?</AccordionTrigger>
           <AccordionContent>
             Les données publiques utilisées par Éclaireur Public peuvent être téléchargées via la
-            barre de navigation ou dans le footer en cliquant sur le bouton télécharger.
+            barre de navigation ou dans le bas de page en cliquant sur le bouton télécharger.
           </AccordionContent>
         </AccordionItem>
         <AccordionItem value='item-15'>

--- a/front/app/components/KPIs.tsx
+++ b/front/app/components/KPIs.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from 'react';
 
 import { fetchKPIs } from '@/utils/fetchers/kpis/fetchKPIs';
-import { cn, formatCompactPrice, formatNumber } from '@/utils/utils';
+import { cn, formatCompactPrice, formatNumberInteger } from '@/utils/utils';
 
 const KPIS_YEAR = 2023;
 
@@ -16,7 +16,7 @@ export default async function KPIs() {
         description='des subventions en montant sont publiées.'
       />
       <ChiffreCle
-        value={formatNumber(kpis.communitiesTotalCount)}
+        value={formatNumberInteger(kpis.communitiesTotalCount)}
         description='collectivités recensées sur le site.'
       />
       <ChiffreCle


### PR DESCRIPTION
This PR fixes : 
- The word "Footer" in the FAQ, unknown for most people. Changed for "bas de page"
- Homepage, project section : collectivité number as integer

Tickets : 
https://noco.services.dataforgood.fr/dashboard/#/nc/p6lbzxq9ra31no8/mpl5qhhyydqkc5v?rowId=26
https://noco.services.dataforgood.fr/dashboard/#/nc/p6lbzxq9ra31no8/mpl5qhhyydqkc5v?rowId=27