### PR TITLE
[BACK] Ajout d'un tâche CRON github action

### DIFF
--- a/.github/workflows/run-main.yaml
+++ b/.github/workflows/run-main.yaml
@@ -1,0 +1,28 @@
+name: "[BACK] Run main.py script"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  run-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Don't run the cron job on forks:
+    if: ${{ github.repository == 'dataforgoodfr/13_eclaireur_public' || github.event_name != 'schedule' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'poetry'
+  
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run main script
+        run: |
+          poetry run python back/main.py

--- a/back/scripts/workflow/workflow_manager.py
+++ b/back/scripts/workflow/workflow_manager.py
@@ -51,13 +51,13 @@ class WorkflowManager:
         return [
             CPVLabelsWorkflow,
             SireneWorkflow,
+            FinancialAccounts,
+            ElectedOfficialsWorkflow.from_config,
+            DeclaInteretWorkflow,
             OfglLoader.from_config,
             CommunitiesSelector,
             DataGouvCatalog,
             MarchesPublicsWorkflow.from_config,
-            FinancialAccounts,
-            ElectedOfficialsWorkflow.from_config,
-            DeclaInteretWorkflow,
             DataGouvSearcher,
             CommunitiesContact,
         ]


### PR DESCRIPTION
Action qui exécute quotidiennement le script `main.py`. Le script peut être lancé manuellement.
Ça serait bien qu'il crée une alerte s'il échoue, mais il y a d'autres priorités :

Actuellement, le script ne va pas jusqu'au bout : le processus est kill lors du `OfglLoader` (téléchargement de plusieurs Go de données ou/et traitements des fichiers).
C'est un problème car ce fichier est nécessaire pour de nombreux workflows.
Entre nous, en local, mon ordinateur capitule au même endroit.
J'ai créé un ticket (P0).

L'ordre d'exécution des workflows a été un peu modifié.
L'objectif - à défaut de faire fonctionner le process jusqu'au bout - est qu'il échoue le plus tard possible : tous les workflows qui ne dépendent pas de `OfglLoader` ont donc été placés avant celui-ci.

Le changement d'ordre des workflows est un peu trop touchy à mon goût, j'ai ajouté un ticket (P3) pour pouvoir visibiliser qui dépend de qui et pouvoir déterminer automatiquement l'ordre d'exécution (ou en tout cas, vérifier sa cohérence).