### PR TITLE
[BACK] new structure for errors detected exported in jsonl

### DIFF
--- a/back/config.yaml
+++ b/back/config.yaml
@@ -123,6 +123,9 @@ logging:
   formatters:
     simple:
       format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    jsonl:
+      format: '{"timestamp": "%(asctime)s", "error_code": "%(error_code)s", "message": "%(message)s", "file_url": "%(file_url)s", "dataset": "%(dataset)s", "step": "%(step)s", "details": %(details)s}'
+      datefmt: "%Y-%m-%dT%H:%M:%SZ"
   handlers:
     console:
       class: logging.StreamHandler
@@ -134,7 +137,12 @@ logging:
       level: DEBUG
       formatter: simple
       filename: back/data/logs/log.txt
+    jsonl:
+      class: logging.FileHandler
+      level: ERROR
+      formatter: jsonl
+      filename: back/data/logs/errors.jsonl
   loggers:
     back:
       level: INFO
-      handlers: [console, file]
+      handlers: [console, file, jsonl]

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -1,8 +1,8 @@
+import datetime
 import hashlib
 import json
 import logging
 import urllib
-import datetime
 from pathlib import Path
 from urllib.error import HTTPError
 
@@ -75,7 +75,7 @@ class DatasetAggregator:
             "file_url": file_url,
             "dataset": dataset,
             "step": step,
-            "details": details or {}
+            "details": details or {},
         }
         self.errors.append(error)  # Ancien système
         ERROR_LOGGER.error(message, extra=error)  # Nouveau logger JSONL
@@ -106,7 +106,7 @@ class DatasetAggregator:
                     file_url=getattr(file_infos, "url", None),
                     dataset=self.get_config_key(),
                     step="process_files",
-                    details={"title": getattr(file_infos, "title", None)}
+                    details={"title": getattr(file_infos, "title", None)},
                 )
                 continue
 
@@ -118,7 +118,7 @@ class DatasetAggregator:
                     file_url=None,
                     dataset=self.get_config_key(),
                     step="process_files",
-                    details={"title": getattr(file_infos, "title", None)}
+                    details={"title": getattr(file_infos, "title", None)},
                 )
                 continue
 
@@ -131,7 +131,7 @@ class DatasetAggregator:
                     message=str(e),
                     file_url=getattr(file_infos, "url", None),
                     dataset=self.get_config_key(),
-                    step="process_files"
+                    step="process_files",
                 )
         self._post_process()
         self._concatenate_files()
@@ -159,14 +159,16 @@ class DatasetAggregator:
             urllib.request.urlretrieve(file_metadata.url, output_filename)
         except HTTPError as error:
             LOGGER.warning(f"Failed to download file {file_metadata.url}: {error}")
-            msg = f"HTTP error {error.code} while expecting {file_metadata.resource_status} code"
+            msg = (
+                f"HTTP error {error.code} while expecting {file_metadata.resource_status} code"
+            )
             self._log_error(
                 error_code="HTTP_ERROR",
                 message=msg,
                 file_url=file_metadata.url,
                 dataset=self.get_config_key(),
                 step="download_file",
-                details={"exception": str(error)}
+                details={"exception": str(error)},
             )
         except Exception as e:
             LOGGER.warning(f"Failed to download file {file_metadata.url}: {e}")
@@ -175,7 +177,7 @@ class DatasetAggregator:
                 message=str(e),
                 file_url=file_metadata.url,
                 dataset=self.get_config_key(),
-                step="download_file"
+                step="download_file",
             )
         LOGGER.debug(f"Downloaded file {file_metadata.url}")
 
@@ -218,7 +220,7 @@ class DatasetAggregator:
                 message=str(e),
                 file_url=file_metadata.url,
                 dataset=self.get_config_key(),
-                step="read_parse_file"
+                step="read_parse_file",
             )
 
     def _normalize_frame(self, df: pd.DataFrame, file_metadata: tuple):
@@ -268,6 +270,9 @@ class DatasetAggregator:
 
     @property
     def aggregated_dataset(self):
+        """
+        Property to return the aggregated dataset.
+        """
         if not self.output_filename.exists():
             raise RuntimeError("Combined file does not exists. You must run .load() first.")
         return pd.read_parquet(self.output_filename)

--- a/back/scripts/utils/logger_manager.py
+++ b/back/scripts/utils/logger_manager.py
@@ -1,11 +1,49 @@
+import datetime
+import json
 import logging
 import logging.config
 import os
+from pathlib import Path
+
+from back.scripts.utils.config import get_project_base_path
+
+
+class JsonlFormatter(logging.Formatter):
+    def format(self, record):
+        log = {
+            "timestamp": getattr(
+                record, "timestamp", datetime.datetime.utcnow().isoformat() + "Z"
+            ),
+            "error_code": getattr(record, "error_code", "UNKNOWN"),
+            "message": record.getMessage(),
+            "file_url": getattr(record, "file_url", None),
+            "dataset": getattr(record, "dataset", None),
+            "step": getattr(record, "step", None),
+            "details": getattr(record, "details", {}),
+        }
+        return json.dumps(log, ensure_ascii=False)
 
 
 class LoggerManager:
     @staticmethod
     def configure_logger(config):
+        # Logger principal configuré via dictConfig
         log_directory = os.path.dirname(config["logging"]["handlers"]["file"]["filename"])
         os.makedirs(log_directory, exist_ok=True)
         logging.config.dictConfig(config["logging"])
+
+        # Logger structuré JSONL pour les erreurs
+        error_log_path = Path(
+            config.get("logging", {}).get(
+                "errors_filename", get_project_base_path() / "errors.jsonl"
+            )
+        )
+        error_log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        handler = logging.FileHandler(error_log_path, mode="a", encoding="utf-8")
+        handler.setFormatter(JsonlFormatter())
+
+        error_logger = logging.getLogger("errors_logger")
+        error_logger.setLevel(logging.ERROR)
+        error_logger.addHandler(handler)
+        error_logger.propagate = False


### PR DESCRIPTION
- Remplacement du format d’erreurs errors.json par un format JSON Lines (errors.jsonl) plus structuré et exploitable.
- Chaque erreur comporte désormais: timestamp, code, message, fichier concerné, étape, etc.
- Centralisation de la gestion des erreurs via la méthode _log_error.
- Génération du fichier errors.jsonl à la fin du pipeline, prêt à être consommé par le front ou des outils BI.

Champs présents dans chaque erreur :

timestamp - string - Date et heure UTC de l’erreur (format ISO 8601, ex : "2025-05-28T15:00:00Z")
error_code - string - Code unique pour le type d’erreur (ex : "FORMAT_NOT_SUPPORTED", "LOAD_FAILED")
message - string -Message lisible décrivant l’erreur
file_url - string - URL ou chemin du fichier concerné (si applicable)
dataset - string - Nom du dataset ou du workflow concerné
step - string - Étape du pipeline où l’erreur est survenue (ex : "process_files", "download_file")
details - objet - Détails techniques additionnels (ex : titre du fichier, exception, etc.)

Exemple d’une ligne :
{"timestamp":"2025-05-28T15:00:00Z","error_code":"FORMAT_NOT_SUPPORTED","message":"Format xls not supported","file_url":"https://example.com/file.xls","dataset":"subventions","step":"process_files","details":{"title":"Budget 2024"}}

Objectifs:
- Faciliter l’exploitation et la visualisation des erreurs côté front.
- Améliorer la traçabilité et le debug des workflows de données.

Si besoin on peut changer la structure assez aisément (même le format de fichier en sortie ;) )

PS: En draft car il faut que je test encore 







