### PR TITLE
[FRONT] : fix : Standardisation des graphs pour les subventions

### DIFF
--- a/front/app/community/[siren]/components/FicheSubventions/SubventionYearlyAmountsChart.tsx
+++ b/front/app/community/[siren]/components/FicheSubventions/SubventionYearlyAmountsChart.tsx
@@ -23,19 +23,27 @@ type SubventionYearlyAmountsChartProps = {
 export function SubventionYearlyAmountsChart({ siren }: SubventionYearlyAmountsChartProps) {
   const { data, isPending, isError } = useSubventionYearlyAmounts(siren);
 
-  if (isPending) {
-    return <Loading style={{ height: CHART_HEIGHT }} />;
+  if (isPending) return <Loading style={{ height: CHART_HEIGHT }} />;
+  if (isError) return <ErrorFetching style={{ height: CHART_HEIGHT }} />;
+
+  const initalList: BarChartData = [];
+  for (let i = 0; i <= 7; i++) {
+    initalList.push({
+      year: new Date(Date.now()).getFullYear() - 7 + i,
+      amount: 0,
+    });
   }
 
-  if (isError) {
-    return <ErrorFetching style={{ height: CHART_HEIGHT }} />;
-  }
+  const chartData: BarChartData = initalList.map((el) => {
+    const found = data.find((item) => item.year === el.year);
+    return { ...el, amount: found?.amount ?? el.amount };
+  });
 
-  return <BarChart data={data} />;
+  return <BarChart data={chartData} />;
 }
 
 const LEGEND_LABELS: Record<Exclude<keyof BarChartData[number], 'year'>, string> = {
-  amount: 'Nombre de subventions publiées',
+  amount: 'Montant des subventions publiées (€)',
 };
 
 function getLegendFormatter(value: Exclude<keyof BarChartData[number], 'year'>): string {
@@ -44,6 +52,11 @@ function getLegendFormatter(value: Exclude<keyof BarChartData[number], 'year'>):
     throw new Error(`Clé de légende inconnue : "${value}".`);
   }
   return label;
+}
+
+function formatLabel(value: number): string {
+  if (value === 0) return "Aucunes données publiées";
+  return formatCompact(value);
 }
 
 type BarChartData = {
@@ -72,8 +85,8 @@ function BarChart({ data }: BarChartProps) {
         <XAxis dataKey='year' axisLine={true} tickLine={true} />
         <YAxis tickFormatter={(value) => formatCompact(value)} />
         <Legend formatter={getLegendFormatter} />
-        <Bar dataKey='amount' stackId='a' fill='#525252' barSize={120} radius={[10, 10, 0, 0]}>
-          <LabelList position='top' formatter={formatCompact} />
+        <Bar dataKey='amount' stackId='a' fill='#525252' radius={[10, 10, 0, 0]}>
+          <LabelList position='top' formatter={formatLabel} />
         </Bar>
       </RechartsBarChart>
     </ResponsiveContainer>

--- a/front/app/community/[siren]/components/FicheSubventions/SubventionYearlyCountsChart.tsx
+++ b/front/app/community/[siren]/components/FicheSubventions/SubventionYearlyCountsChart.tsx
@@ -23,19 +23,27 @@ type SubventionTrendsStackedBarChartProps = {
 export function SubventionyearlyCountsChart({ siren }: SubventionTrendsStackedBarChartProps) {
   const { data, isPending, isError } = useSubventionYearlyCounts(siren);
 
-  if (isPending) {
-    return <Loading style={{ height: CHART_HEIGHT }} />;
+  if (isPending) return <Loading style={{ height: CHART_HEIGHT }} />;
+  if (isError) return <ErrorFetching style={{ height: CHART_HEIGHT }} />;
+
+  const initalList: BarChartData = [];
+  for (let i = 0; i <= 7; i++) {
+    initalList.push({
+      year: new Date(Date.now()).getFullYear() - 7 + i,
+      count: 0,
+    });
   }
 
-  if (isError) {
-    return <ErrorFetching style={{ height: CHART_HEIGHT }} />;
-  }
+  const chartData: BarChartData = initalList.map((el) => {
+    const found = data.find((item) => item.year === el.year);
+    return { ...el, count: found?.count ?? el.count };
+  });
 
-  return <BarChart data={data} />;
+  return <BarChart data={chartData} />;
 }
 
 const LEGEND_LABELS: Record<Exclude<keyof BarChartData[number], 'year'>, string> = {
-  count: 'Subventions publiées (€)',
+  count: 'Nombre de subventions publiées',
 };
 
 function getLegendFormatter(value: Exclude<keyof BarChartData[number], 'year'>): string {
@@ -44,6 +52,11 @@ function getLegendFormatter(value: Exclude<keyof BarChartData[number], 'year'>):
     throw new Error(`Clé de légende inconnue : "${value}".`);
   }
   return label;
+}
+
+function formatLabel(value: number): string {
+  if (value === 0) return "Aucunes données publiées";
+  return formatCompact(value);
 }
 
 type BarChartData = {
@@ -72,8 +85,8 @@ function BarChart({ data }: BarChartProps) {
         <XAxis dataKey='year' axisLine={true} tickLine={true} />
         <YAxis tickFormatter={(value) => formatCompact(value)} />
         <Legend formatter={getLegendFormatter} />
-        <Bar dataKey='count' stackId='a' fill='#525252' barSize={120} radius={[10, 10, 0, 0]}>
-          <LabelList position='top' formatter={formatCompact} />
+        <Bar dataKey='count' stackId='a' fill='#525252' radius={[10, 10, 0, 0]}>
+          <LabelList position='top' formatter={formatLabel} />
         </Bar>
       </RechartsBarChart>
     </ResponsiveContainer>


### PR DESCRIPTION
Cette PR standardise les graphiques d'évolution des subventions selon les modalités suivantes : 
- Affichage des 8 dernières années
- Pour les années sans données, un message "Aucunes données publiées" apparait sur les années en question