### PR TITLE
[BACK] chore: privileged use of BaseLoader instead of LOADER_CLASSES

### DIFF
--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 
 from back.scripts.datasets.dataset_aggregator import DatasetAggregator
-from back.scripts.loaders import LOADER_CLASSES
+from back.scripts.loaders import BaseLoader
 from back.scripts.utils.dataframe_operation import (
     IdentifierFormat,
     normalize_column_names,
@@ -63,7 +63,7 @@ class OfglLoader(DatasetAggregator):
         # We are forced to use csv which need some typing help
         opts = {"columns": READ_COLUMNS.keys(), "dtype": COM_CSV_DTYPES}
 
-        loader = LOADER_CLASSES[file_metadata.format](raw_filename, **opts)
+        loader = BaseLoader.loader_factory(raw_filename, **opts)
         df = (
             loader.load()
             .rename(columns={k: v for k, v in READ_COLUMNS.items() if v})

--- a/back/scripts/datasets/communities_financial_accounts.py
+++ b/back/scripts/datasets/communities_financial_accounts.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from back.scripts.datasets.dataset_aggregator import DatasetAggregator
-from back.scripts.loaders.utils import LOADER_CLASSES
+from back.scripts.loaders import BaseLoader
 from back.scripts.utils.dataframe_operation import normalize_date
 from back.scripts.utils.typing import PandasRow
 
@@ -31,7 +31,7 @@ class FinancialAccounts(DatasetAggregator):
     def _read_parse_file(
         self, file_metadata: PandasRow, raw_filename: Path
     ) -> pd.DataFrame | None:
-        loader = LOADER_CLASSES[file_metadata.format](raw_filename)
+        loader = BaseLoader.loader_factory(raw_filename)
         df = loader.load().assign(type=file_metadata.type)
         self.columns.update(df.columns)
         selected_columns = {

--- a/back/scripts/datasets/dataset_aggregator.py
+++ b/back/scripts/datasets/dataset_aggregator.py
@@ -11,7 +11,7 @@ import polars as pl
 from tqdm import tqdm
 
 from back.scripts.datasets.utils import BaseDataset
-from back.scripts.loaders import LOADER_CLASSES
+from back.scripts.loaders import LOADER_CLASSES, BaseLoader
 from back.scripts.utils.decorators import tracker
 from back.scripts.utils.typing import PandasRow
 
@@ -169,7 +169,7 @@ class DatasetAggregator(BaseDataset):
         self, file_metadata: PandasRow, raw_filename: Path
     ) -> pd.DataFrame | None:
         opts = {"dtype": str} if file_metadata.format == "csv" else {}
-        loader = LOADER_CLASSES[file_metadata.format](raw_filename, **opts)
+        loader = BaseLoader.loader_factory(raw_filename, **opts)
         try:
             df = loader.load()
             if not isinstance(df, pd.DataFrame):

--- a/back/scripts/loaders/zip_loader.py
+++ b/back/scripts/loaders/zip_loader.py
@@ -93,9 +93,9 @@ class ZipLoader(BaseLoader):
         """
         # First, try to find the archive file loader class based on the filename
         filename = self.get_archive_prefix()
-        filename_extension = filename.rsplit(".", 1)[-1]
-        if filename_extension in LOADER_CLASSES:
-            return LOADER_CLASSES[filename_extension]
+        loader_class = BaseLoader.search_loader_class(filename)
+        if loader_class:
+            return loader_class
 
         # Second, try to find the archive file loader class based on the url path
         url_path = urlparse(self.file_url).path


### PR DESCRIPTION
Utiliser directement `LOADER_CLASSES` est tentant mais c'est `BaseLoader` qui contient la logique de son utilisation.
