### PR TITLE
[BACK] feat: add LoaderBase.get_loader_kwargs

### DIFF
--- a/back/scripts/loaders/base_loader.py
+++ b/back/scripts/loaders/base_loader.py
@@ -60,6 +60,7 @@ class BaseLoader:
             file_url : URL of the file to load
             num_retries: Number of retries in case of failure
             delay_between_retries: Delay between retries in seconds
+            kwargs: Keyword arguments used when loading the file
         """
         self.file_url = str(file_url)
         self.num_retries = num_retries
@@ -103,6 +104,13 @@ class BaseLoader:
 
     def process_data(self, data):
         raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def get_loader_kwargs(self) -> dict:
+        """
+        Returns:
+            Dictionary of keyword arguments used when loading the file
+        """
+        return self.kwargs
 
     @classmethod
     def loader_factory(cls, file_url: str | Path, **loader_kwargs) -> Self:

--- a/back/scripts/loaders/csv_loader.py
+++ b/back/scripts/loaders/csv_loader.py
@@ -17,39 +17,35 @@ WINDOWS_NEWLINE = re.compile(r"\r\n?")
 class CSVLoader(EncodedDataLoader):
     file_extensions = {"csv"}
     file_media_type_regex = re.compile(r"csv", flags=re.IGNORECASE)
+    """
+    Initialize the CSV loader for either URL or local file.
+    """
 
-    def __init__(
-        self, *args, columns: list[str] | None = None, dtype: dict | None = None, **kwargs
-    ):
-        """
-        Initialize the CSV loader for either URL or local file.
+    def get_loader_kwargs(self):
+        kwargs = super().get_loader_kwargs()
+        kwargs |= {
+            "on_bad_lines": "skip",
+            "low_memory": False,
+        }
+        # Sometimes you don't know which loader class is going to be called, especially during a `BaseLoader.loader_factory`
+        # columns attribute is useful for `parquet_loader` and usecols attribute for `csv_loader` and `excel_loader`
+        if "columns" in kwargs:
+            kwargs["usecols"] = kwargs.pop("columns")
 
-        Args:
-            columns (list, optional): List of column names to keep
-            dtype (dict, optional): Dictionary of column data types
-        """
-        super().__init__(*args, **kwargs)
-        self.columns = columns
-        self.dtype = dtype
+        return kwargs
 
     def process_from_decoded(self, decoded_content) -> pd.DataFrame | None:
+        loader_kwargs = self.get_loader_kwargs()
+
+        # If the delimiter is not specified, try to detect it
         decoded_content = STARTING_NEWLINE.sub("", decoded_content)
         decoded_content = WINDOWS_NEWLINE.sub("\n", decoded_content)
         sniffer = csv.Sniffer()
         sample = decoded_content[: min(4096, len(decoded_content))]
-        csv_params = {
-            "on_bad_lines": "skip",
-            "low_memory": False,
-        }
-        if self.dtype is not None:
-            csv_params["dtype"] = self.dtype
-
-        if self.columns is not None:
-            csv_params["usecols"] = lambda c: c in self.columns
 
         try:
             dialect = sniffer.sniff(sample)
-            csv_params["header"] = 0 if sniffer.has_header(sample) else None
+            loader_kwargs["header"] = 0 if sniffer.has_header(sample) else None
         except csv.Error as e:
             LOGGER.warning(f"CSV Sniffer error: {e}")
             # Try to find the most common delimiter
@@ -58,11 +54,11 @@ class CSVLoader(EncodedDataLoader):
         else:
             delimiter = dialect.delimiter
 
-        csv_params["delimiter"] = delimiter
+        loader_kwargs["delimiter"] = delimiter
         LOGGER.debug(f"Detected delimiter: '{delimiter}'")
 
         try:
-            df = pd.read_csv(StringIO(decoded_content), **csv_params)
+            df = pd.read_csv(StringIO(decoded_content), **loader_kwargs)
         except Exception as e:
             LOGGER.warning(f"Error while reading CSV: {e}")
             return

--- a/back/scripts/loaders/csv_loader.py
+++ b/back/scripts/loaders/csv_loader.py
@@ -30,7 +30,8 @@ class CSVLoader(EncodedDataLoader):
         # Sometimes you don't know which loader class is going to be called, especially during a `BaseLoader.loader_factory`
         # columns attribute is useful for `parquet_loader` and usecols attribute for `csv_loader` and `excel_loader`
         if "columns" in kwargs:
-            kwargs["usecols"] = kwargs.pop("columns")
+            columns = kwargs.pop("columns")
+            kwargs["usecols"] = lambda c: c in columns
 
         return kwargs
 

--- a/back/scripts/loaders/excel_loader.py
+++ b/back/scripts/loaders/excel_loader.py
@@ -19,18 +19,14 @@ class ExcelLoader(BaseLoader):
     file_extensions = {"xls", "xlsx", "excel"}
     file_media_type_regex = re.compile(r"(excel|spreadsheet|xls|xlsx)", flags=re.IGNORECASE)
 
-    def __init__(
-        self, *args, dtype: dict | None = None, columns: list[str] | None = None, **kwargs
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.dtype = dtype
-        self.columns = columns
+    def get_loader_kwargs(self):
+        kwargs = super().get_loader_kwargs()
+        if "columns" in kwargs:
+            kwargs["usecols"] = kwargs.pop("columns")
+
+        return kwargs
 
     def process_data(self, data: bytes) -> pd.DataFrame:
-        df = pd.read_excel(BytesIO(data), dtype=self.dtype)
-
-        if self.columns is not None:
-            df = df[self.columns]
-
+        df = pd.read_excel(BytesIO(data), **self.get_loader_kwargs())
         LOGGER.debug(f"Excel Data from {self.file_url} loaded.")
         return df

--- a/back/scripts/loaders/json_loader.py
+++ b/back/scripts/loaders/json_loader.py
@@ -27,10 +27,10 @@ class JSONLoader(BaseLoader):
     def process_data(self, data):
         content = None
         if isinstance(data, str):
-            content = json.loads(data)
+            content = json.loads(data, **self.get_loader_kwargs())
         elif isinstance(data, bytes):
             # utile dans les cas où l'encodage n'est pas utf-8
-            content = json.load(BytesIO(data))
+            content = json.load(BytesIO(data), **self.get_loader_kwargs())
         else:
             raise Exception("Unhandled type")
 

--- a/back/scripts/loaders/parquet_loader.py
+++ b/back/scripts/loaders/parquet_loader.py
@@ -13,23 +13,13 @@ LOGGER = logging.getLogger(__name__)
 
 @register_loader
 class ParquetLoader(BaseLoader):
-    """
-
-    Args:
-        columns (list, optional): List of column names to keep
-    """
-
     file_extensions = {"parquet"}
-
-    def __init__(self, *args, columns: list[str] | None = None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.columns = columns
 
     def _load_from_url(self) -> pd.DataFrame:
         with tempfile.TemporaryDirectory() as tempdir:
             filename = Path(tempdir) / "test.parquet"
             urllib.request.urlretrieve(self.file_url, filename)
-            return pd.read_parquet(filename, columns=self.columns)
+            return pd.read_parquet(filename, **self.get_loader_kwargs())
 
     def _load_from_file(self) -> pd.DataFrame:
-        return pd.read_parquet(self.file_url, columns=self.columns)
+        return pd.read_parquet(self.file_url, **self.get_loader_kwargs())

--- a/back/scripts/loaders/xml_loader.py
+++ b/back/scripts/loaders/xml_loader.py
@@ -15,7 +15,7 @@ class XMLLoader(EncodedDataLoader):
 
     def process_from_decoded(self, decoded_content):
         try:
-            df = pd.read_xml(StringIO(decoded_content))
+            df = pd.read_xml(StringIO(decoded_content), **self.get_loader_kwargs())
         except Exception as e:
             LOGGER.warning(f"Error while reading XML: {e}")
             return

--- a/back/scripts/loaders/zip_loader.py
+++ b/back/scripts/loaders/zip_loader.py
@@ -26,9 +26,13 @@ class ZipLoader(BaseLoader):
     def process_data(self, *args, **kwargs):
         if self.archived_file_loader_class is None:
             # TODO?: add a raw parameter in addition to the file_url
-            loader_class = BaseLoader.loader_factory(self.output_file_path, **self.kwargs)
+            loader_class = BaseLoader.loader_factory(
+                self.output_file_path, **self.get_loader_kwargs()
+            )
         else:
-            loader_class = self.archived_file_loader_class(self.output_file_path, **self.kwargs)
+            loader_class = self.archived_file_loader_class(
+                self.output_file_path, **self.get_loader_kwargs()
+            )
         return loader_class.load()
 
     def _load_from_url(self):


### PR DESCRIPTION
L'objectif de cette PR est de flexibiliser l'utilisation des Loader en permettant de définir tous les paramètres nécessaires pour charger les fichiers lors de son initialisation.
Actuellement, on gère spécifiquement le `dtype`, parfois `columns`.
Dans Geolocator, on aurait besoin de `decimal` par exemple et il faudrait donc définir ce cas unitairement. Autant généraliser ça.
Les attributs sont fournis lors de l'initialisation du Loader `CSVLoader(file_url, sep=";", dtype={"siren": str}, …)`, ces attributs sont appelés lors du chargement du fichier.

`get_loader_kwargs` permet de pouvoir surcharger plus finement les attributs fournis lors du init (voir `CsvLoader` pour l'exemple).

L'utilisation de `get_loader_kwargs` a été généralisé à tous les loaders.