### PR TITLE
[BACK] feat(OFGL): ajout filtre avant téléchargement

### DIFF
--- a/back/scripts/datasets/ofgl_urls.csv
+++ b/back/scripts/datasets/ofgl_urls.csv
@@ -1,5 +1,5 @@
 type;url;format;code
-regions;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-regions-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B;csv;REG
-departements;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-departements-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B;csv;DEP
-groupements_fiscalite_propre;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-gfp-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B;csv;MET
-communes;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-communes-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B;csv;COM
+regions;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-regions-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B&select=exer%2C%20outre_mer%2C%20categ%2C%20ptot%2C%20siren%2C%20reg_code;csv;REG
+departements;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-departements-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B&select=exer%2C%20outre_mer%2C%20categ%2C%20ptot%2C%20siren%2C%20reg_code%2C%20dep_code;csv;DEP
+groupements_fiscalite_propre;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-gfp-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B&select=exer%2C%20outre_mer%2C%20categ%2C%20ptot%2C%20siren%2C%20reg_code%2C%20dep_code;csv;MET
+communes;https://data.ofgl.fr/api/explore/v2.1/catalog/datasets/ofgl-base-communes-consolidee/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B&select=exer%2C%20outre_mer%2C%20categ%2C%20ptot%2C%20siren%2C%20reg_code%2C%20dep_code%2C%20insee;csv;COM


### PR DESCRIPTION
Cette PR permet de ne télécharger que les champs utiles du workflow Ofgl plutôt que tout télécharger pour ensuite les filtrer.
Cela permet de réduire fortement la taille des fichiers et l'impact sur le CPU lors de leur lecture.
La qualité des résultats ne devrait pas être impactée.