### PR TITLE
[BACK] feat: cron will work only sunday and wednesday

### DIFF
--- a/.github/workflows/run-main.yaml
+++ b/.github/workflows/run-main.yaml
@@ -3,7 +3,7 @@ name: "[BACK] Run main.py script"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 2 * * 0,3"
 
 jobs:
   run-main:


### PR DESCRIPTION
Pour que le script main ne s'exécute que deux fois par semaine au lieu de tous les jours afin de ne pas surcharger les appels à la CI github.