### PR TITLE
fix: update ofgl for 2024 data

### DIFF
--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -29,7 +29,9 @@ READ_COLUMNS = {
     "Code Insee Collectivité": "code_insee",
     "Code Siren Collectivité": "siren",
     "Code Insee 2023 Département": "code_insee_dept",
+    "Code Insee 2024 Département": "code_insee_dept",
     "Code Insee 2023 Région": "code_insee_region",
+    "Code Insee 2024 Région": "code_insee_region",
 }
 
 


### PR DESCRIPTION
Des colonnes changent de noms : 
<img width="1701" height="802" alt="image" src="https://github.com/user-attachments/assets/aff9e1fe-9727-40fb-b245-6d1af9ab98c6" />


C'est pas incroyable de devoir faire ça manuellement. 