### PR TITLE
[BACK] chore(ofgl): add guard against null df in _read_parse_file method

### DIFF
--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -66,28 +66,30 @@ class OfglLoader(DatasetAggregator):
         opts = {"columns": READ_COLUMNS.keys(), "dtype": COM_CSV_DTYPES}
 
         loader = BaseLoader.loader_factory(raw_filename, **opts)
-        df = (
-            loader.load()
-            .rename(columns={k: v for k, v in READ_COLUMNS.items() if v})
-            .pipe(normalize_column_names)
-            .assign(
-                type=file_metadata.code,
-                outre_mer=lambda df: (df["outre_mer"] == "Oui").fillna(False),
+        df = loader.load()
+        if df :
+            df = (
+                df
+                .rename(columns={k: v for k, v in READ_COLUMNS.items() if v})
+                .pipe(normalize_column_names)
+                .assign(
+                    type=file_metadata.code,
+                    outre_mer=lambda df: (df["outre_mer"] == "Oui").fillna(False),
+                )
             )
-        )
 
-        insee_col = self.INSEE_COL.get(file_metadata.code)
-        if insee_col:
-            df = df.assign(code_insee=lambda df: df[insee_col])
+            insee_col = self.INSEE_COL.get(file_metadata.code)
+            if insee_col:
+                df = df.assign(code_insee=lambda df: df[insee_col]) 
 
-        df = (
-            df.sort_values("exercice", ascending=False)
-            .drop_duplicates(subset=["siren"], keep="first")
-            .pipe(normalize_identifiant, id_col="siren", format=IdentifierFormat.SIREN)
-        )
+            df = (
+                df.sort_values("exercice", ascending=False)
+                .drop_duplicates(subset=["siren"], keep="first")
+                .pipe(normalize_identifiant, id_col="siren", format=IdentifierFormat.SIREN)
+            )
 
-        self.columns = pd.concat(
-            [self.columns, pd.DataFrame({file_metadata.code: 1}, index=df.columns)], axis=1
-        )
-        self.columns.to_csv(self.data_folder / "columns.csv")
+            self.columns = pd.concat(
+                [self.columns, pd.DataFrame({file_metadata.code: 1}, index=df.columns)], axis=1
+            )
+            self.columns.to_csv(self.data_folder / "columns.csv")
         return df

--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -67,10 +67,9 @@ class OfglLoader(DatasetAggregator):
 
         loader = BaseLoader.loader_factory(raw_filename, **opts)
         df = loader.load()
-        if df :
+        if df:
             df = (
-                df
-                .rename(columns={k: v for k, v in READ_COLUMNS.items() if v})
+                df.rename(columns={k: v for k, v in READ_COLUMNS.items() if v})
                 .pipe(normalize_column_names)
                 .assign(
                     type=file_metadata.code,
@@ -80,7 +79,7 @@ class OfglLoader(DatasetAggregator):
 
             insee_col = self.INSEE_COL.get(file_metadata.code)
             if insee_col:
-                df = df.assign(code_insee=lambda df: df[insee_col]) 
+                df = df.assign(code_insee=lambda df: df[insee_col])
 
             df = (
                 df.sort_values("exercice", ascending=False)

--- a/back/scripts/datasets/cpv_labels.py
+++ b/back/scripts/datasets/cpv_labels.py
@@ -16,4 +16,6 @@ class CPVLabelsWorkflow(BaseDataset):
     def run(self) -> None:
         if self.output_filename.exists():
             return
-        BaseLoader.loader_factory(self.config["url"]).load().to_parquet(self.output_filename)
+        loader = BaseLoader.loader_factory(self.config["url"]).load()
+        if loader:
+            loader.to_parquet(self.output_filename)


### PR DESCRIPTION
## Description 

Cette PR ajoute une condition `if df`: dans la méthode _read_parse_file du OfglLoader, afin de s'assurer que les transformations ne sont appliquées que si le DataFrame est valide.

Si loader.load() retourne None, on ne souhaite pas appliquer des méthodes comme .rename() qui provoqueraient une erreur.