### PR TITLE
[BACK] permettre la lecture de json non conformes.

### DIFF
--- a/back/scripts/datasets/marches.py
+++ b/back/scripts/datasets/marches.py
@@ -110,21 +110,25 @@ class MarchesPublicsWorkflow(DatasetAggregator):
         if interim_fn.exists():
             return
 
+        array_location = self.check_json_structure(raw_filename)
+
+        def select_items(content):
+            """
+            filter top level elements according to detected json structure.
+            """
+            root_structure = array_location.split(".")
+            for top_level in root_structure:
+                if top_level in content: # what to do when 'root_structure == "unknown"'
+                    content = content[top_level]
+            return content
+
         with open(raw_filename, "rb") as raw:
-            array_location = self.check_json_structure(raw_filename) + ".item"
-
+            raw_loaded = json.load(raw)
+            raw_loaded = select_items(raw_loaded)
             with open(interim_fn, "w") as interim:
-                # Ijson identifies each declaration individually
-                # within the marches field.
-                array_declas = ijson.items(
-                    raw,
-                    array_location,
-                    use_float=True,
-                )
                 interim.write("[\n")
-
                 # Iterate over the JSON array items
-                for i, declaration in enumerate(array_declas):
+                for i, declaration in enumerate(raw_loaded):
                     if i:
                         interim.write(",\n")
                     unnested = [json.dumps(x) for x in self.unnest_marche(declaration)]


### PR DESCRIPTION
quelques json des marchés publics ne respectent pas le standard JSON. remplacement de ijson (respectueux) par json (librairie python standard plus souple)

quelques impacts :
TLDR: temps d'executions légèrement inférieurs et impact mémoire assez important ; mais on reste loin du traitement le plus gourmand.
Les fichiers intermédiaires produits sont identiques.

execution : 
main : avec ijson
2025-07-20 10:54:42,045 - back.scripts.datasets.dataset_aggregator - INFO - start : function_=run
2025-07-20 10:54:49,305 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=7.247; memory_=2.0Go
2025-07-20 10:55:00,144 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=6.683; memory_=2.6Go
2025-07-20 10:55:04,296 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=0.446; memory_=2.8Go
2025-07-20 10:55:23,002 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=18.418; memory_=2.8Go
2025-07-20 10:55:44,594 - back.scripts.datasets.dataset_aggregator - INFO - Concatenating 4 files for /home/gilbow/Prog/13_eclaireur_public/back/data/marches_publics/marches_publics.parquet
[...] # plus gourmand
2025-07-20 10:55:46,644 - back.scripts.enrichment.subventions_enricher - INFO - start : function_=enrich
2025-07-20 10:55:48,086 - back.scripts.enrichment.subventions_enricher - INFO - tracker : function_=enrich; duration_=1.441; memory_=11.4Go
[...] # fin
2025-07-20 10:55:48,086 - back.scripts.enrichment.base_enricher - INFO - start : function_=enrich
2025-07-20 10:55:48,086 - back.scripts.enrichment.base_enricher - INFO - tracker : function_=enrich; duration_=0.0; memory_=11.4Go

back-suppression_ijson_pour_lecture_marches : avec json
2025-07-20 11:29:01,175 - back.scripts.datasets.dataset_aggregator - INFO - start : function_=run
2025-07-20 11:29:07,645 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=6.456; memory_=2.7Go
2025-07-20 11:29:17,804 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=5.919; memory_=2.9Go
2025-07-20 11:29:21,863 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=0.385; memory_=2.9Go
2025-07-20 11:29:39,223 - back.scripts.datasets.marches - INFO - tracker : function_=_read_parse_interim; duration_=17.064; memory_=5.5Go
2025-07-20 11:30:02,261 - back.scripts.datasets.dataset_aggregator - INFO - Concatenating 4 files for /home/gilbow/Prog/13_eclaireur_public/back/data/marches_publics/marches_publics.parquet
[...] # plus gourmand
2025-07-20 11:30:05,280 - back.scripts.enrichment.subventions_enricher - INFO - start : function_=enrich
2025-07-20 11:30:06,925 - back.scripts.enrichment.subventions_enricher - INFO - tracker : function_=enrich; duration_=1.644; memory_=11.1Go
[...] # fin
2025-07-20 11:30:06,926 - back.scripts.enrichment.base_enricher - INFO - start : function_=enrich
2025-07-20 11:30:06,926 - back.scripts.enrichment.base_enricher - INFO - tracker : function_=enrich; duration_=0.0; memory_=11.1Go


comparaison des fichiers intermédiaires produits : 

$ diff -r before/ after/ --report-identical-files
Les fichiers before/16962018-5c31-4296-9454-5998585496d2/interim.json et after/16962018-5c31-4296-9454-5998585496d2/interim.json sont identiques
Les fichiers before/4fafdaff-b697-4494-9523-e9f56916fea8/interim.json et after/4fafdaff-b697-4494-9523-e9f56916fea8/interim.json sont identiques
Les fichiers before/59ba0edb-cf94-4bf1-a546-61f561553917/interim.json et after/59ba0edb-cf94-4bf1-a546-61f561553917/interim.json sont identiques
Les fichiers before/d00a6a5a-beef-442e-8aee-5867f47a87d0/interim.json et after/d00a6a5a-beef-442e-8aee-5867f47a87d0/interim.json sont identiques
