### PR TITLE
[BACK] Fix/ofgl 2024

### DIFF
--- a/back/scripts/communities/loaders/ofgl.py
+++ b/back/scripts/communities/loaders/ofgl.py
@@ -20,6 +20,8 @@ COM_CSV_DTYPES = {
     "Code Insee Collectivité": str,
     "Code Insee 2023 Département": str,
     "Code Insee 2023 Région": str,
+    "Code Insee 2024 Région": str,
+    "Code Insee 2024 Département": str,
 }
 READ_COLUMNS = {
     "Exercice": None,


### PR DESCRIPTION
Un code insee `02` est lu `2` suite au passage de OFGL en 2024 car je n'ai pas forcé le type à `str` à la lecture dans [cette PR](https://github.com/dataforgoodfr/13_eclaireur_public/pull/307)