### PR TITLE
[FRONT] Standardiser l’affichage des tableaux Marchés Publics et Subventions

### DIFF
--- a/front/app/community/[siren]/components/FicheMarchesPublics/MarchesPublicsTable.tsx
+++ b/front/app/community/[siren]/components/FicheMarchesPublics/MarchesPublicsTable.tsx
@@ -46,7 +46,7 @@ export default function MarchesPublicsTable({
   }
 
   if (data.length === 0) {
-    return <NoData />;
+    return <NoData style={{ height: CHART_HEIGHT }} />;
   }
 
   const rows: Row[] = data.map(({ id, titulaire_names, objet, montant, annee_notification }) => ({
@@ -93,11 +93,11 @@ export function Table({ rows }: Table) {
         {rows.map(({ id, names, object, amount, year }) => (
           <TableRow key={id}>
             <TableCell>
-              {names.map((name) => (
+              {names.map((name) => name ? (
                 <Badge key={name} className='m-1'>
                   {name}
                 </Badge>
-              ))}
+              ) : null)}
             </TableCell>
             <TableCell>{object.toLocaleUpperCase()}</TableCell>
             <TableCell className='text-right'>{formatAmount(amount)}</TableCell>

--- a/front/app/community/[siren]/components/FicheSubventions/Ranking.tsx
+++ b/front/app/community/[siren]/components/FicheSubventions/Ranking.tsx
@@ -1,25 +1,14 @@
 'use client';
 
-// TODO: Replace all `any` types with proper interfaces/types for better type safety.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from 'react';
 
 import DownloadButton from '#app/community/[siren]/components/DownloadDataButton';
 import YearSelector from '#app/community/[siren]/components/YearSelector';
 import { Subvention } from '#app/models/subvention';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '#components/ui/table';
-import { formatCompactPrice } from '#utils/utils';
+import { usePagination } from '#utils/hooks/usePagination';
 
 import { YearOption } from '../../types/interface';
-
-const ROWS_COUNT = 10;
+import RankingTable from './RankingTable';
 
 export default function Ranking({
   data,
@@ -29,38 +18,13 @@ export default function Ranking({
   availableYears: number[];
 }) {
   const defaultYear: YearOption = availableYears.length > 0 ? Math.max(...availableYears) : 'All';
-  const [linesDisplayed, setLinesDisplayed] = useState(0);
   const [selectedYear, setSelectedYear] = useState<YearOption>(defaultYear);
+  const paginationProps = usePagination();
 
-  const filteredData =
-    selectedYear === 'All'
-      ? data
-      : data.filter((item) => String(item.annee) === String(selectedYear));
-
-  function formatSubventionObject(input: string): string[] {
-    return input
-      .replace(/[\[\]]/g, '') // Supprime les crochets
-      .replace(/\\r\\n|\r\n|\n/g, ' ') // Retire les \n\r
-      .split(/',|",/) // Split sur des virgules
-      .map((item) =>
-        item
-          .trim()
-          .replace(/^['"]|['"]$/g, '')
-          .toLocaleUpperCase(),
-      );
+  function handleSelectedYear(option: YearOption) {
+    setSelectedYear(option);
+    paginationProps.onPageChange(1);
   }
-
-  function getTopSubs(data: any[]) {
-    const sortedSubs = data.sort((a, b) => Number(b.montant) - Number(a.montant));
-    const topSubs =
-      sortedSubs.length > ROWS_COUNT + ROWS_COUNT * linesDisplayed
-        ? sortedSubs.slice(0, ROWS_COUNT + ROWS_COUNT * linesDisplayed)
-        : sortedSubs;
-
-    return topSubs;
-  }
-
-  const topSubsData = getTopSubs(filteredData);
 
   return (
     <>
@@ -69,56 +33,11 @@ export default function Ranking({
           <h3 className='py-2 text-xl'>Classement par tailles de subventions</h3>
         </div>
         <div className='flex items-center gap-2'>
-          {/* TODO: Fix year selector with this table */}
-          <YearSelector defaultValue={defaultYear} onSelect={setSelectedYear} />
+          <YearSelector defaultValue={defaultYear} onSelect={handleSelectedYear} />
           <DownloadButton />
         </div>
       </div>
-      <Table className='min-h-[600px]'>
-        <TableHeader>
-          <TableRow>
-            <TableHead className='w-[300px]'>Bénéficiaires</TableHead>
-            <TableHead className=''>Objet</TableHead>
-            <TableHead className='w-[140px] text-right'>Montant</TableHead>
-            <TableHead className='w-[140px] text-right'>Année</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {topSubsData.map((item, index) => (
-            <TableRow key={index}>
-              <TableCell className='font-medium'>
-                <div className='line-clamp-1 overflow-hidden text-ellipsis'>
-                  {item.nom_beneficiaire}
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className='line-clamp-1 overflow-hidden text-ellipsis'>
-                  {formatSubventionObject(item.objet).map((item, index) => (
-                    <span key={index}>
-                      {index > 0 && ' - '}
-                      {item}
-                    </span>
-                  ))}
-                </div>
-              </TableCell>
-              <TableCell className='text-right'>
-                {formatCompactPrice(parseFloat(item.montant))}
-              </TableCell>
-              <TableCell className='text-right'>{item.annee}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      {filteredData.length > ROWS_COUNT + ROWS_COUNT * linesDisplayed && (
-        <div className='flex items-center justify-center pt-6'>
-          <button
-            className='rounded-md bg-neutral-600 px-3 py-1 text-neutral-100 hover:bg-neutral-800'
-            onClick={() => setLinesDisplayed(linesDisplayed + 1)}
-          >
-            Voir plus
-          </button>
-        </div>
-      )}
+      <RankingTable data={data} year={selectedYear} paginationProps={paginationProps} />
     </>
   );
 }

--- a/front/app/community/[siren]/components/FicheSubventions/RankingTable.tsx
+++ b/front/app/community/[siren]/components/FicheSubventions/RankingTable.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Subvention } from '#app/models/subvention';
+import { PaginationProps, WithPagination } from '#components/Pagination';
+import { Badge } from '#components/ui/badge';
+import {
+  Table as ShadCNTable,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '#components/ui/table';
+import { formatAmount } from '#utils/utils';
+
+import { YearOption } from '../../types/interface';
+import { CHART_HEIGHT } from '../constants';
+import { NoData } from '../NoData';
+
+const ROWS_COUNT = 10;
+
+interface RankingTableProps {
+  data: Subvention[];
+  year: YearOption;
+  paginationProps: Omit<PaginationProps, 'totalPage'>;
+}
+
+export default function RankingTable({ data, year, paginationProps }: RankingTableProps) {
+  const filteredData =
+    year === 'All' ? data : data.filter((item) => String(item.annee) === String(year));
+
+  function getShownSubs(data: Subvention[]) {
+    const sortedSubs = data.sort((a, b) => Number(b.montant) - Number(a.montant));
+    const subs = sortedSubs.slice(
+      ROWS_COUNT * (paginationProps.activePage - 1),
+      ROWS_COUNT * paginationProps.activePage,
+    );
+
+    return subs;
+  }
+
+  const totalPage = Math.ceil(filteredData.length / ROWS_COUNT);
+  const rows = getShownSubs(filteredData);
+
+  if (rows.length === 0) {
+    return <NoData style={{ height: CHART_HEIGHT }} />;
+  }
+
+  return (
+    <>
+      <WithPagination style={{ height: CHART_HEIGHT }} totalPage={totalPage} {...paginationProps}>
+        <Table rows={rows} />
+      </WithPagination>
+    </>
+  );
+}
+
+function Table({ rows }: { rows: Subvention[] }) {
+  function formatSubventionObject(input: string): string[] {
+    return input
+      .replace(/[\[\]]/g, '') // Supprime les crochets
+      .replace(/\\r\\n|\r\n|\n/g, ' ') // Retire les \n\r
+      .split(/',|",/) // Split sur des virgules
+      .map((item) =>
+        item
+          .trim()
+          .replace(/^['"]|['"]$/g, '')
+          .toLocaleUpperCase(),
+      );
+  }
+
+  return (
+    <ShadCNTable>
+      <TableHeader>
+        <TableRow>
+          <TableHead className='w-[300px]'>Bénéficiaires</TableHead>
+          <TableHead className=''>Objet</TableHead>
+          <TableHead className='w-[140px] text-right'>Montant (€)</TableHead>
+          <TableHead className='w-[140px] text-right'>Année</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((item, index) => (
+          <TableRow key={index}>
+            <TableCell className='font-medium'>
+              { item.nom_beneficiaire ? <Badge className='m-1'>
+                {item.nom_beneficiaire}
+              </Badge> : null }
+            </TableCell>
+            <TableCell>
+              {formatSubventionObject(item.objet).map((item, index) => (
+                <span key={index}>
+                  {index > 0 && ' - '}
+                  {item}
+                </span>
+              ))}
+            </TableCell>
+            <TableCell className='text-right'>{formatAmount(item.montant)}</TableCell>
+            <TableCell className='text-right'>{item.annee}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </ShadCNTable>
+  );
+}

--- a/front/app/community/[siren]/components/NoData.tsx
+++ b/front/app/community/[siren]/components/NoData.tsx
@@ -1,9 +1,9 @@
-export function NoData() {
+export function NoData({ style }: { style?: React.CSSProperties }) {
   return (
-    <div className="flex h-[200px] w-full items-center justify-center bg-gray-50 rounded-lg">
-      <div className="text-center">
-        <p className="text-lg font-medium text-gray-600">Aucune donnée disponible</p>
-        <p className="text-sm text-gray-500 mt-1">
+    <div className='flex h-[200px] w-full items-center justify-center rounded-lg bg-gray-50' style={style}>
+      <div className='text-center'>
+        <p className='text-lg font-medium text-gray-600'>Aucune donnée disponible</p>
+        <p className='mt-1 text-sm text-gray-500'>
           Il n&apos;y a pas de données à afficher pour le moment.
         </p>
       </div>

--- a/front/components/ui/tabs.tsx
+++ b/front/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 w-full items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+    'inline-flex h-9 w-full items-center justify-center rounded-lg bg-accent p-1 text-muted-foreground',
       className,
     )}
     {...props}


### PR DESCRIPTION
- Aligner le style du tableau subventions sur marchés public
- Quelques petits autres changements mineurs
  - Fixer la hauteur des tableaux à `CHART_HEIGHT` même quand pas de data
  - Cacher le badge de la première colonne si string vide
  - Fix temporaire de la couleur des tabs pour la lisibilité

<img width="646" height="991" alt="Screenshot 2025-08-05 at 12 32 40" src="https://github.com/user-attachments/assets/bb6a5651-6f62-4aed-8f46-d2ecac67976c" />
<img width="640" height="995" alt="Screenshot 2025-08-05 at 12 32 50" src="https://github.com/user-attachments/assets/486d3745-c911-47e8-814e-247aaa72d054" />
