### PR TITLE
[FRONT/BACK] chore(ci): apply ruff only on back

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
     hooks:
       - id: ruff
         args: [--select, I, --fix]
+        files: back/.*
       - id: ruff-format
+        files: back/.*
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:


### PR DESCRIPTION
apply ruff only on back as there is now python in front that does not comply with the linter.