### PR TITLE
[FRONT] Fix - Fetch TransparencyScore from Communities Table + fetch Aggregated Score 

### DIFF
--- a/front/app/(visualiser)/interpeller/[siren]/step1/page.tsx
+++ b/front/app/(visualiser)/interpeller/[siren]/step1/page.tsx
@@ -21,11 +21,11 @@ async function getCommunity(siren: string) {
     throw new Error(`Community doesnt exist with siren ${siren}`);
   }
 
-  const { aggregatedScore, evolutionGlobalScore } = await fetchMostRecentTransparencyScore(siren);
+  const { bareme, evolutionGlobalScore } = await fetchMostRecentTransparencyScore(siren);
 
   return {
     ...communitiesResults[0],
-    transparencyScore: aggregatedScore,
+    transparencyScore: bareme?.global_score || null,
     evolutionGlobalScore,
   };
 }
@@ -33,7 +33,7 @@ export default async function InterpellateStep1({ params }: CommunityPageProps) 
   const { siren } = await params;
   const community = await getCommunity(siren);
 
-  const score = community.transparencyScore || TransparencyScore.UNKNOWN;
+  const score = (community.transparencyScore as TransparencyScore) || TransparencyScore.UNKNOWN;
   const trend = community.evolutionGlobalScore || 'Stable';
 
   return (

--- a/front/app/community/[siren]/components/FicheMarchesPublics/FicheMarchesPublics.tsx
+++ b/front/app/community/[siren]/components/FicheMarchesPublics/FicheMarchesPublics.tsx
@@ -62,6 +62,9 @@ export async function FicheMarchesPublics({
   // Fetch transparency score for Marchés Publics
   const { bareme } = await fetchMostRecentTransparencyScore(siren);
   const transparencyIndex = bareme?.mp_score || null;
+
+  console.log(bareme);
+
   return (
     <FicheCard header={<MarchesPublicsHeader transparencyIndex={transparencyIndex} />}>
       {marchesPublics.length > 0 ? (

--- a/front/app/community/[siren]/components/FicheMarchesPublics/FicheMarchesPublics.tsx
+++ b/front/app/community/[siren]/components/FicheMarchesPublics/FicheMarchesPublics.tsx
@@ -63,8 +63,6 @@ export async function FicheMarchesPublics({
   const { bareme } = await fetchMostRecentTransparencyScore(siren);
   const transparencyIndex = bareme?.mp_score || null;
 
-  console.log(bareme);
-
   return (
     <FicheCard header={<MarchesPublicsHeader transparencyIndex={transparencyIndex} />}>
       {marchesPublics.length > 0 ? (

--- a/front/app/community/[siren]/page.tsx
+++ b/front/app/community/[siren]/page.tsx
@@ -35,11 +35,11 @@ async function getCommunity(siren: string) {
     throw new Error(`Community doesnt exist with siren ${siren}`);
   }
 
-  const { aggregatedScore, evolutionGlobalScore } = await fetchMostRecentTransparencyScore(siren);
+  const { bareme, evolutionGlobalScore } = await fetchMostRecentTransparencyScore(siren);
 
   return {
     ...communitiesResults[0],
-    transparencyScore: aggregatedScore,
+    transparencyScore: bareme?.global_score || null,
     evolutionGlobalScore,
   };
 }
@@ -53,7 +53,7 @@ export default async function CommunityPage({ params }: CommunityPageProps) {
 
   // TODO - get and add the last update date
   // const lastUpdateText = `Derniere mise a jour`;
-  const score = community.transparencyScore || TransparencyScore.UNKNOWN;
+  const score = (community.transparencyScore as TransparencyScore) || TransparencyScore.UNKNOWN;
   const trend = community.evolutionGlobalScore || 'Stable';
 
   return (

--- a/front/app/models/bareme.ts
+++ b/front/app/models/bareme.ts
@@ -6,4 +6,5 @@ export type Bareme = {
   mp_score: TransparencyScore | null;
   subventions_score: TransparencyScore | null;
   evolution_global_score: string | null;
+  global_score: string | null;
 };

--- a/front/app/models/community.ts
+++ b/front/app/models/community.ts
@@ -19,6 +19,7 @@ export type Community = {
   longitude: number | null;
   mp_score: TransparencyScore | null;
   subventions_score: TransparencyScore | null;
+  global_score: TransparencyScore | null;
   siren_epci: string;
   naf8: string;
   tranche_effectif: number;

--- a/front/utils/fetchers/communities/fetchTransparencyScore-server.ts
+++ b/front/utils/fetchers/communities/fetchTransparencyScore-server.ts
@@ -40,19 +40,20 @@ export async function fetchMostRecentTransparencyScore(siren: string): Promise<{
   bareme: Bareme | null;
   evolutionGlobalScore: string | null;
 }> {
+  /**
+   * TODO - Fetch the only from the COMMUNITIES_TABLE_NAME
+   */
   const querySQL = `
-    SELECT 
+    SELECT
       c.siren,
-      b.annee, 
-      b.subventions_score,
-      b.mp_score,
-      b.evolution_global_score,
-      b.global_score
+      c.subventions_score,
+      c.mp_score,
+      c.global_score,
+      b.annee,
+      b.evolution_global_score
     FROM ${COMMUNITIES_TABLE_NAME} c
-    LEFT JOIN ${BAREME_TABLE_NAME} b on b.siren = c.siren
-    WHERE c.siren = $1 
-    ORDER BY b.annee DESC
-    LIMIT 1
+    LEFT JOIN ${BAREME_TABLE_NAME} b ON b.siren = c.siren AND b.annee = 2023
+    WHERE c.siren = $1
   `;
 
   const rows = (await getQueryFromPool(querySQL, [siren])) as Bareme[];

--- a/front/utils/fetchers/communities/fetchTransparencyScore-server.ts
+++ b/front/utils/fetchers/communities/fetchTransparencyScore-server.ts
@@ -1,5 +1,4 @@
 import { Bareme } from '#app/models/bareme';
-import { TransparencyScore } from '#components/TransparencyScore/constants';
 import { getQueryFromPool } from '#utils/db';
 
 import { DataTable } from '../constants';
@@ -25,43 +24,6 @@ function createSQLQueryParams(siren: string, year: number): [string, (string | n
 }
 
 /**
- * Calculate the aggregated transparency score based on subventions and marchés publics scores
- * Uses the average of the two scores (E=5, D=4, C=3, B=2, A=1)
- */
-export function calculateAggregatedScore(
-  subventionsScore: TransparencyScore | null,
-  mpScore: TransparencyScore | null,
-): TransparencyScore | null {
-  if (!subventionsScore && !mpScore) return null;
-  if (!subventionsScore) return mpScore;
-  if (!mpScore) return subventionsScore;
-
-  // If either score is UNKNOWN, return UNKNOWN
-  if (subventionsScore === TransparencyScore.UNKNOWN || mpScore === TransparencyScore.UNKNOWN) {
-    return TransparencyScore.UNKNOWN;
-  }
-
-  const scoreValues: Record<Exclude<TransparencyScore, TransparencyScore.UNKNOWN>, number> = {
-    [TransparencyScore.A]: 1,
-    [TransparencyScore.B]: 2,
-    [TransparencyScore.C]: 3,
-    [TransparencyScore.D]: 4,
-    [TransparencyScore.E]: 5,
-  };
-  const valueToScore: Record<number, Exclude<TransparencyScore, TransparencyScore.UNKNOWN>> = {
-    1: TransparencyScore.A,
-    2: TransparencyScore.B,
-    3: TransparencyScore.C,
-    4: TransparencyScore.D,
-    5: TransparencyScore.E,
-  };
-
-  const avgValue = Math.round((scoreValues[subventionsScore] + scoreValues[mpScore]) / 2);
-
-  return valueToScore[avgValue];
-}
-
-/**
  * Fetch the transparency score of a community for a given year
  */
 export async function fetchTransparencyScore(siren: string, year: number): Promise<Bareme> {
@@ -76,7 +38,6 @@ export async function fetchTransparencyScore(siren: string, year: number): Promi
  */
 export async function fetchMostRecentTransparencyScore(siren: string): Promise<{
   bareme: Bareme | null;
-  aggregatedScore: TransparencyScore | null;
   evolutionGlobalScore: string | null;
 }> {
   const querySQL = `
@@ -85,7 +46,8 @@ export async function fetchMostRecentTransparencyScore(siren: string): Promise<{
       b.annee, 
       b.subventions_score,
       b.mp_score,
-      b.evolution_global_score
+      b.evolution_global_score,
+      b.global_score
     FROM ${COMMUNITIES_TABLE_NAME} c
     LEFT JOIN ${BAREME_TABLE_NAME} b on b.siren = c.siren
     WHERE c.siren = $1 
@@ -96,9 +58,5 @@ export async function fetchMostRecentTransparencyScore(siren: string): Promise<{
   const rows = (await getQueryFromPool(querySQL, [siren])) as Bareme[];
   const bareme = rows[0] || null;
 
-  const aggregatedScore = bareme
-    ? calculateAggregatedScore(bareme.subventions_score, bareme.mp_score)
-    : null;
-
-  return { bareme, aggregatedScore, evolutionGlobalScore: bareme?.evolution_global_score || null };
+  return { bareme, evolutionGlobalScore: bareme?.evolution_global_score || null };
 }


### PR DESCRIPTION
Les scores de transparences actuels sont dans la table collectivités (et correspondent à 2023 de la table bareme). Chloé va apporter une modification pour rajouter une colonne dans cette table pour la tendance afin de fetcher à un seul endroit.
Le score agrégé est déjà calculé par le back, pas besoin de le recalculer au front mais juste de le fetch