### PR TITLE
[FRONT] Fix advanced search : add type collectivite GRP

### DIFF
--- a/front/utils/format.ts
+++ b/front/utils/format.ts
@@ -23,11 +23,6 @@ export function formatCommunityType(type: CommunityType): string {
     [CommunityType.Region]: 'Région',
     [CommunityType.Departement]: 'Département',
     [CommunityType.Commune]: 'Commune',
-    [CommunityType.Metropole]: 'Métropole',
-    [CommunityType.CTU]: 'Collectivité territoriale unique',
-    [CommunityType.CA]: "Communauté d'agglomération",
-    [CommunityType.CC]: 'Communauté de communes',
-    [CommunityType.EPT]: 'Établissement public territorial',
     [CommunityType.GRP]: 'Groupement',
   };
 

--- a/front/utils/helpers/getDefaultComparisonScope.ts
+++ b/front/utils/helpers/getDefaultComparisonScope.ts
@@ -18,13 +18,8 @@ export function getDefaultComparisonScope(communityType: CommunityType): Scope {
     case CommunityType.Departement:
       return 'Régional';
     case CommunityType.Commune:
-    case CommunityType.Metropole:
-    case CommunityType.CA:
-    case CommunityType.CC:
-    case CommunityType.EPT:
+    case CommunityType.GRP:
       return 'Départemental';
-    case CommunityType.CTU:
-      return 'National';
     default:
       return 'Départemental'; // Fallback par défaut
   }

--- a/front/utils/types.ts
+++ b/front/utils/types.ts
@@ -2,16 +2,6 @@ export enum CommunityType {
   Region = 'REG',
   Departement = 'DEP',
   Commune = 'COM',
-  /** Metropole au sens de la ville principale d une region geographique */
-  Metropole = 'MET',
-  /** Collectivite territoriale unique (ex: Corse, Martinique, Guyane) */
-  CTU = 'CTU',
-  /** Communaute d'agglomerations */
-  CA = 'CA',
-  /** Communaute de communes */
-  CC = 'CC',
-  /** Etablissement public territorial */
-  EPT = 'EPT',
   /** Groupement */
   GRP = 'GRP',
 }

--- a/front/utils/utils.ts
+++ b/front/utils/utils.ts
@@ -186,13 +186,8 @@ export function formatNomsPropres(str: string): string {
 }
 
 export function stringifyCommunityType(type: CommunityType): string {
-  if (type === CommunityType.CA) return `Communauté d'agglomération`;
-  if (type === CommunityType.CC) return 'Communauté de communes';
-  if (type === CommunityType.CTU) return 'Collectivité territoriale unique';
   if (type === CommunityType.Commune) return 'Commune';
   if (type === CommunityType.Departement) return 'Département';
-  if (type === CommunityType.EPT) return 'Établissement public territorial';
-  if (type === CommunityType.Metropole) return 'Groupement';
   if (type === CommunityType.Region) return 'Région';
   if (type === CommunityType.GRP) return 'Groupement';
 


### PR DESCRIPTION
Ajout d'un nouveau type de collectivité : Groupement 

Il y a l'air d'avoir eu une mise à jour. La répartition de la table collectivité par type donne ça maintenant. Il y a beaucoup moins de diversité. Je me suis contenté d'ajouter le nouveau type. 
97	DEP
34823	COM
17	REG
1266	GRP