### PR TITLE
fix(communities-contacts): handle title change in data.gouv.fr dataset

### DIFF
--- a/back/scripts/datasets/communities_contacts.py
+++ b/back/scripts/datasets/communities_contacts.py
@@ -89,7 +89,8 @@ class CommunitiesContact(BaseDataset):
             .pipe(
                 lambda df: df.loc[
                     (df["dataset_id"] == self.DATASET_ID)
-                    & (df["title"] == "Base de données locales de Service-public"),
+                    & (df["title"].str.startswith("Base de données locales de Service-public"))
+                    & (df["format"] == "json"),
                     "id",
                 ]
             )


### PR DESCRIPTION
## Summary
- Fix `CommunitiesContact` workflow failing with "list index out of range" error
- The data.gouv.fr dataset title changed from "Base de données locales de Service-public" to "Base de données locales de Service-public.gouv.fr"
- Use `startswith()` for title matching instead of exact match
- Add `format == "json"` filter to ensure we select the correct resource (the dataset has multiple resources: PDFs, xlsx, and JSON)

## Test plan
- [x] Verified the filter returns exactly 1 match with the new criteria
- [x] Run pipeline with production config to confirm the workflow completes