### PR TITLE
[FRONT] Fix NaN display in marchés publics table

### DIFF
--- a/front/utils/fetchers/marches-publics/fetchMarchesPublicsPaginated-server.ts
+++ b/front/utils/fetchers/marches-publics/fetchMarchesPublicsPaginated-server.ts
@@ -15,10 +15,10 @@ function createSQLQueryParams(
   const values: (string | number)[] = [siren];
 
   let query = `
-    SELECT 
-      id_mp as id, 
-      objet, 
-      montant_du_marche_public as montant, 
+    SELECT
+      id_mp,
+      objet,
+      montant_du_marche_public,
       annee_notification,
       ARRAY_AGG(titulaire_denomination_sociale) AS titulaire_names,
       count(*) OVER()::integer AS total_row_count


### PR DESCRIPTION
## Summary
- Fix NaN values displayed in the marchés publics table for montant and id columns
- The SQL query was using aliases (`id_mp as id`, `montant_du_marche_public as montant`) but the frontend component expected the original column names (`id_mp`, `montant_du_marche_public`)
- Removed the aliases to match the `PaginatedMarchePublic` TypeScript type

## Test plan
- [x] Navigate to a community page with marchés publics data (e.g., `/community/200046977`)
- [x] Verify the table displays correct montant values instead of NaN
- [x] Verify pagination still works correctly
- [x] Test with different years filter