### PR TITLE
[BACK] fix(community): add missing SIRENE effectif code 53

### DIFF
--- a/back/scripts/datasets/sirene.py
+++ b/back/scripts/datasets/sirene.py
@@ -26,6 +26,7 @@ EFFECTIF_CODE_TO_EMPLOYEES = {
     "42": 1000,
     "51": 2000,
     "52": 5000,
+    "53": 10000,
 }
 
 # Rate limiting configuration

--- a/front/app/community/[siren]/components/CommunityDetails.tsx
+++ b/front/app/community/[siren]/components/CommunityDetails.tsx
@@ -74,7 +74,7 @@ function InfoBlock({
           )}
         </p>
         <h4 className='flex items-center text-lg font-bold'>
-          {isTailleAdministration && numericValue >= 5000 && (
+          {isTailleAdministration && numericValue >= 10000 && (
             <span className='ml-1 mr-1 text-base font-normal sm:inline'>Plus de </span>
           )}
           <SlidingNumber
@@ -89,7 +89,7 @@ function InfoBlock({
               mass: 0.4,
             }}
           />
-          {isTailleAdministration && numericValue > 0 && numericValue < 5000 && (
+          {isTailleAdministration && numericValue > 0 && numericValue < 10000 && (
             <>
               <span className='ml-1 mr-1 text-base font-normal sm:inline'>à </span>
               <SlidingNumber

--- a/front/utils/utils.ts
+++ b/front/utils/utils.ts
@@ -221,6 +221,6 @@ export function getAllYearsFrom2018ToCurrent(): number[] {
 }
 
 export function getNextTranche(currentTranche: number): number {
-  const trancheValues = [0, 1, 3, 6, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000];
+  const trancheValues = [0, 1, 3, 6, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
   return trancheValues[trancheValues.indexOf(currentTranche) + 1];
 }


### PR DESCRIPTION
## Summary
- Added effectif code 53 (10000+ employees) to `EFFECTIF_CODE_TO_EMPLOYEES` mapping in SIREN workflow
- This was missing and caused regions like Ile-de-France to show 0 agents instead of their actual count (10000+)

## Test plan
- [x] Re-ran SIREN pipeline with fresh data
- [x] Verified Ile-de-France (SIREN 237500079) now shows `tranche_effectif = 10000` in database
- [x] Confirmed website displays "Plus de 10000 agents" correctly