### PR TITLE
[BACK] fix(communities): update EPCI data URL

### DIFF
--- a/back/config-test.yaml
+++ b/back/config-test.yaml
@@ -10,7 +10,7 @@ ofgl:
 communities:
   data_folder: back/tests/data/communities
   combined_filename: back/tests/data/communities/communities.parquet
-  epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
+  epci_url: https://www.collectivites-locales.gouv.fr/files/files/Etudes-et-statistiques/Liste%20et%20composition%20des%20EPCI%20%C3%A0%20fiscalit%C3%A9%20propre/2025/epcicom2025-2.xlsx
   odf_url: file:./back/scripts/datasets/odf.csv
 
   geolocator:

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -10,7 +10,7 @@ ofgl:
 communities:
   data_folder: back/data/communities
   combined_filename: back/data/communities/communities.parquet
-  epci_url: https://www.collectivites-locales.gouv.fr/files/Accueil/DESL/2025/epcicom2025-2.xlsx
+  epci_url: https://www.collectivites-locales.gouv.fr/files/files/Etudes-et-statistiques/Liste%20et%20composition%20des%20EPCI%20%C3%A0%20fiscalit%C3%A9%20propre/2025/epcicom2025-2.xlsx
   odf_url: file:back/scripts/datasets/odf.csv
 
   geolocator:


### PR DESCRIPTION
## Summary
- Update EPCI data URL in config files after collectivites-locales.gouv.fr changed their URL structure
- The old URL (`/files/Accueil/DESL/2025/epcicom2025-2.xlsx`) now returns 404
- New URL points to the same 2025 EPCI data at the updated location

## Test plan
- [x] Run `poetry run python back/main.py` and verify CommunitiesSelector workflow completes successfully
- [x] Verify EPCI data is correctly loaded (check for `siren` and `siren_membre` columns)

## Context
The government website reorganized their file structure. The EPCI composition data (mapping communes to their EPCI) is now located under `/files/files/Etudes-et-statistiques/Liste%20et%20composition%20des%20EPCI%20à%20fiscalité%20propre/2025/`.