### PR TITLE
[FRONT] fix(db): correct contacts table name typo

### DIFF
--- a/front/utils/fetchers/constants.ts
+++ b/front/utils/fetchers/constants.ts
@@ -9,5 +9,5 @@ export enum DataTable {
   MarchesPublics = 'marches_publics',
   Elus = 'elus',
   Bareme = 'bareme',
-  Contacts = 'communties_contacts',
+  Contacts = 'communities_contacts',
 }


### PR DESCRIPTION
## Summary

Fix typo in `DataTable` enum: `communties_contacts` → `communities_contacts`

This typo was introduced in commit d1172315 (May 2025) when the Contacts enum was first added. The frontend has been querying a non-existent table, causing HTTP 500 errors on `/interpeller/[siren]/step2`.

## Root Cause

- **Backend** creates table: `communities_contacts`
- **Frontend** queries table: `communties_contacts` (missing "i")

## Test Plan

- [ ] Verify `/interpeller/[siren]/step2` no longer returns HTTP 500
- [ ] Verify contacts are displayed correctly on the interpellate page