### PR TITLE
Remove all Transparency International references from the website

### DIFF
--- a/front/app/(a-propos)/faq/page.tsx
+++ b/front/app/(a-propos)/faq/page.tsx
@@ -22,7 +22,7 @@ const faqItems: FaqItem[] = [
     id: 'item-2',
     question: 'Puis-je avoir confiance en Éclaireur Public\u00A0?',
     answer:
-      'Éclaireur Public est porté par deux associations reconnues pour leur engagement en faveur de la transparence et contre la corruption. Anticor et Transparency International.',
+      'Éclaireur Public est porté par Anticor, association reconnue pour son engagement en faveur de la transparence et contre la corruption, et accompagné par Data for Good.',
   },
   {
     id: 'item-3',
@@ -73,7 +73,7 @@ const faqItems: FaqItem[] = [
     id: 'item-8',
     question: "J'ai déjà alerté un ou des élus, rien ne se passe, quels sont mes recours\u00A0?",
     answer:
-      "Si après avoir interpellé les élus de votre collectivité aucune réponse n'est apportée dans un délai de 2 mois vous pouvez saisir la Commission d'Accès aux Documents Administratifs (CADA) via le site MaDada.fr. La CADA pourra enjoindre la collectivité à publier les informations demandées. Vous pouvez également contacter Anticor ou Transparency International pour être accompagné dans vos démarches.",
+      "Si après avoir interpellé les élus de votre collectivité aucune réponse n'est apportée dans un délai de 2 mois vous pouvez saisir la Commission d'Accès aux Documents Administratifs (CADA) via le site MaDada.fr. La CADA pourra enjoindre la collectivité à publier les informations demandées. Vous pouvez également contacter Anticor pour être accompagné dans vos démarches.",
   },
   {
     id: 'item-9',
@@ -169,7 +169,7 @@ const faqItems: FaqItem[] = [
     id: 'item-17',
     question: 'Qui puis-je contacter pour des informations\u00A0?',
     answer:
-      'Pour toute question, vous pouvez contacter Anticor ou Transparency International. Un formulaire de contact sera également disponible sur la page',
+      'Pour toute question, vous pouvez contacter Anticor. Un formulaire de contact sera également disponible sur la page',
   },
   {
     id: 'item-18',

--- a/front/app/(a-propos)/qui-sommes-nous/page.tsx
+++ b/front/app/(a-propos)/qui-sommes-nous/page.tsx
@@ -7,7 +7,7 @@ import { Card } from '#components/ui/card';
 export const metadata: Metadata = {
   title: 'Qui sommes-nous ?',
   description:
-    "Eclaireur Public c'est Anticor, Transparency International France, Data for Good et une cinquantaine de bénévoles",
+    "Eclaireur Public c'est Anticor, Data for Good et une cinquantaine de bénévoles",
 };
 
 export default function Page() {
@@ -18,39 +18,9 @@ export default function Page() {
       </div>
       <div className='m-4 rounded-3xl border border-primary-light p-8 md:m-16 xl:mx-auto xl:max-w-[1128px]'>
         <p className='hidden text-3xl font-extrabold md:block md:text-4xl'>
-          Eclaireur Public est le fruit de la collaboration entre Transparency International France,
-          ANTICOR et Data for Good.
+          Eclaireur Public est le fruit de la collaboration entre ANTICOR et Data for Good.
         </p>
-        <div className='my-10 grid gap-10 md:grid-cols-3'>
-          <div className='flex h-full w-full flex-col'>
-            <div className='relative mb-4 h-[90px]'>
-              <Image
-                src='/transparency-international-france.png'
-                fill
-                objectFit='contain'
-                alt='Logo de Transparency International France'
-              />
-            </div>
-            <WhoWeAreCard colorClassName='bg-brand-1 flex-1'>
-              <h2 className='my-5 text-2xl font-extrabold md:text-3xl'>
-                Transparency International France
-              </h2>
-              <p className='my-3 text-lg'>
-                Transparency International France est une association qui vise à promouvoir la
-                transparence afin qu’Etats, entreprises, sociétés civiles et individus ne soient
-                plus confrontés à la corruption.
-              </p>
-              <p className='my-3 text-lg'>
-                Son action porte sur 3 axes - le plaidoyer, le contentieux et l’accompagnement.
-              </p>
-              <p className='my-3 text-lg'>
-                Pour en savoir plus :{' '}
-                <Link href='https://transparency-france.org/' className='border-b-2 border-black'>
-                  visiter le site de Transparency International France
-                </Link>
-              </p>
-            </WhoWeAreCard>
-          </div>
+        <div className='my-10 grid gap-10 md:grid-cols-2'>
           <div className='flex h-full w-full flex-col'>
             <div className='relative mb-4 h-[90px]'>
               <Image src='/anticor.png' fill objectFit='contain' alt="Logo d'ANTICOR" />
@@ -60,16 +30,16 @@ export default function Page() {
               <p className='my-3 text-lg'>
                 ANTICOR est une association transpartisane qui vise à lutter contre la corruption
                 afin de réhabiliter le rapport de confiance qui doit exister entre les citoyens et
-                leurs représentants – autant politiques qu’administratifs.
+                leurs représentants – autant politiques qu'administratifs.
               </p>
               <p className='my-3 text-lg'>
-                Son action porte sur l’invitation d’engagement des candidats sur l’éthique ainsi que
-                l’accompagnement des lanceurs d’alerte pour les affaires judiciaires.
+                Son action porte sur l'invitation d'engagement des candidats sur l'éthique ainsi que
+                l'accompagnement des lanceurs d'alerte pour les affaires judiciaires.
               </p>
               <p className='my-3 text-lg'>
                 Pour en savoir plus :{' '}
                 <Link href='https://anticor.org/' className='border-b-2 border-black'>
-                  visiter le site d’ANTICOR
+                  visiter le site d'ANTICOR
                 </Link>
               </p>
             </WhoWeAreCard>
@@ -82,12 +52,12 @@ export default function Page() {
               <h2 className='my-5 text-2xl font-extrabold md:text-3xl'>Data for Good</h2>
               <p className='my-3 text-lg'>
                 Data for Good est un collectif réunissant des professionnels et des porteurs de
-                projets à impact positif afin d’accompagner ces derniers à la mise en place concrète
+                projets à impact positif afin d'accompagner ces derniers à la mise en place concrète
                 de ces projets.
               </p>
               <p className='my-3 text-lg'>
-                Son action s’articule via la mobilisation des compétences, la formation des citoyens
-                et des bénévoles ainsi que la réflexion sur l’intelligence artificielle.
+                Son action s'articule via la mobilisation des compétences, la formation des citoyens
+                et des bénévoles ainsi que la réflexion sur l'intelligence artificielle.
               </p>
               <p className='my-3 text-lg'>
                 Pour en savoir plus :{' '}
@@ -108,8 +78,8 @@ export default function Page() {
           />
           <h3 className='my-5 text-4xl font-extrabold'>Les bénévoles</h3>
           <p className='my-3 text-lg md:text-xl'>
-            Transparency International France, Anticor et Data for Good remercient chaleureusement
-            tous les bénévoles qui se sont impliqués.
+            Anticor et Data for Good remercient chaleureusement tous les bénévoles qui se sont
+            impliqués.
           </p>
         </div>
       </div>

--- a/front/app/(comprendre)/methodologie/page.tsx
+++ b/front/app/(comprendre)/methodologie/page.tsx
@@ -35,8 +35,8 @@ export default function Page() {
           <div className='grid grid-cols-1 gap-10 md:grid-cols-2'>
             <div className='space-y-6'>
               <p className='text-lg'>
-                Pour parvenir à ces fins, Transparency International France et Anticor ont rédigé de
-                concert un document préparatoire intitulé «&nbsp;Eclaireur Public - Analyse de la
+                Pour parvenir à ces fins, Anticor a rédigé un document préparatoire
+                intitulé «&nbsp;Eclaireur Public - Analyse de la
                 transparence des collectivités locales&nbsp;» définissant les objectifs généraux et
                 un cadre qui donne corps à l'objet «&nbsp;Eclaireur Public&nbsp;», site internet
                 «&nbsp;permettant aux visiteurs de consulter des données à jour sur sa collectivité

--- a/front/app/components/Footer.tsx
+++ b/front/app/components/Footer.tsx
@@ -26,12 +26,6 @@ const FOOTER_DATA = {
       imgAlt: 'Anticor',
       name: 'Anticor',
     },
-    {
-      href: 'https://transparency-france.org/',
-      imgSrc: '/logos/assos/Transparency international.svg',
-      imgAlt: 'Transparency International',
-      name: 'Transparency International',
-    },
   ],
   navigation: [
     {

--- a/front/app/components/Navbar/index.tsx
+++ b/front/app/components/Navbar/index.tsx
@@ -60,7 +60,7 @@ const aProposMenus = [
   {
     title: 'Qui sommes-nous ?',
     href: '/qui-sommes-nous',
-    description: 'Transparency International France, ANTICOR, Data for Good',
+    description: 'ANTICOR, Data for Good',
   },
   {
     title: 'Le projet',

--- a/front/app/components/ProjectDescription.tsx
+++ b/front/app/components/ProjectDescription.tsx
@@ -25,8 +25,8 @@ export default async function ProjectDescription() {
             <div className='mb-3 text-lg'>
               <p className='my-6 text-lg'>
                 Depuis 2016, les collectivités de plus de 3500 habitants doivent publier leurs données d'intérêt général.
-                Pourtant, seules 10% le font. Transparency International France et Anticor estiment
-                que la confiance citoyenne repose sur l'exemplarité des institutions.
+                Pourtant, seules 10% le font. Anticor estime que la confiance citoyenne repose sur
+                l'exemplarité des institutions.
               </p>
               <p className='mt-6 text-lg'>Le projet Éclaireur Public vise à :</p>
               <ul className='ml-5 list-disc'>

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     canonical: './',
   },
   description:
-    'Éclaireur Public est une initiative portée par Transparency International France et Anticor. Le projet vise à pallier le manque de transparence dans la gestion des dépenses publiques des collectivités locales en France.',
+    'Éclaireur Public est une initiative portée par Anticor et accompagnée par Data for Good. Le projet vise à pallier le manque de transparence dans la gestion des dépenses publiques des collectivités locales en France.',
   robots: 'noindex, nofollow',
   keywords: [
     'Transparence financière',


### PR DESCRIPTION
## Summary

Transparency International France is no longer associated with the Éclaireur Public project. This PR removes all user-facing references to the organization across the website.

### Changes

**Footer** (`Footer.tsx`): Remove Transparency International from the "À l'initiative de" section (logo + link).

**Qui sommes-nous** (`qui-sommes-nous/page.tsx`): Remove the TI card entirely, switch from 3-column to 2-column grid (Anticor + Data for Good), update heading and bénévoles acknowledgment text, update page metadata.

**Navbar** (`Navbar/index.tsx`): Update "Qui sommes-nous" dropdown description from "Transparency International France, ANTICOR, Data for Good" → "ANTICOR, Data for Good".

**Homepage metadata** (`layout.tsx`): Update site-wide meta description from "portée par Transparency International France et Anticor" → "portée par Anticor et accompagnée par Data for Good".

**Homepage project section** (`ProjectDescription.tsx`): Update text from "Transparency International France et Anticor estiment..." → "Anticor estime...".

**Méthodologie** (`methodologie/page.tsx`): Reword preparatory document attribution from "TI France et Anticor ont rédigé de concert" → "Anticor a rédigé".

**FAQ** (`faq/page.tsx`): Update three answers (items 2, 8, 17) that mentioned Transparency International.

### Not changed

Internal code identifiers (`TransparencyScore` enum, `fetchTransparencyScore`, etc.) are **not** renamed — they refer to the transparency *scoring concept*, not the organization. The SVG logo file (`/logos/assos/Transparency international.svg`) remains on disk but is no longer referenced by any component.

cc @jb-delafosse @m4xim1nus

Made with [Cursor](https://cursor.com)