### PR TITLE
Update mentions légales with complete legal information

### DIFF
--- a/front/app/legal/page.tsx
+++ b/front/app/legal/page.tsx
@@ -15,30 +15,33 @@ export default function MentionsLegales() {
         <div>
           <h2 className='mb-4'>1. Éditeur du site</h2>
           <p>
-            Le site Éclaireur Public est édité par l’association Anticor [à compléter avec la
-            dénomination juridique exacte], dont le siège social est situé au&nbsp;:
+            Le site Éclaireur Public est édité par l'association ANTICOR (association loi 1901,
+            active depuis le 25/04/2003, fondée en juin 2002), dont le siège social est situé
+            au&nbsp;:
           </p>
-          <p>[Adresse complète]</p>
-          <p>[Numéro SIREN/SIRET]</p>
+          <p>37-39 avenue Ledru Rollin, CS 11237, 75570 Paris Cedex 12 – France.</p>
+          <p className='mt-2'>SIREN&nbsp;: 533 081 782 — Numéro TVA&nbsp;: FR53533081782.</p>
+          <p className='mt-2'>
+            Directrice de la publication&nbsp;: Emma TAILLEFER, en qualité de Présidente.
+          </p>
         </div>
         <div>
           <h2 className='mb-4'>2. Hébergeur</h2>
           <p>Le site est hébergé par&nbsp;:</p>
-          <ul>
-            <li>[Nom de l’hébergeur]</li>
-            <li>[Adresse de l’hébergeur]</li>
-            <li>[Téléphone de l’hébergeur]</li>
-          </ul>
+          <p className='mt-2 font-semibold'>Clever Cloud SAS</p>
+          <p>4 rue Voltaire, 44000 Nantes, France</p>
+          <p>Téléphone&nbsp;: 02 85 52 07 69</p>
         </div>
         <div>
           <h2 className='mb-4'>3. Propriété intellectuelle</h2>
           <p>
-            L’ensemble des contenus présents sur le site (textes, images, logos, éléments
+            L'ensemble des contenus présents sur le site (textes, images, logos, éléments
             graphiques, code) sont protégés par le droit de la propriété intellectuelle.
           </p>
           <p>
             Toute reproduction ou réutilisation est autorisée uniquement dans le cadre de la licence
-            d’utilisation définie sur ce site. La source “Éclaireur Public” doit être mentionnée.
+            d'utilisation définie sur ce site. La source &quot;Éclaireur Public&quot; doit être
+            mentionnée.
           </p>
         </div>
         <div>
@@ -53,9 +56,16 @@ export default function MentionsLegales() {
           </p>
           <p>
             Conformément à la réglementation (RGPD et loi Informatique et Libertés), vous disposez
-            d’un droit d’accès, de rectification et de suppression de vos données.
+            d'un droit d'accès, de rectification et de suppression de vos données.
           </p>
-          <p>Pour l’exercer, vous pouvez nous écrire à : [adresse e-mail de contact].</p>
+          <p>
+            Pour l'exercer, vous pouvez contacter notre DPO&nbsp;:{' '}
+            <a href='mailto:jbsoufron@fwpa-avocats.com' className='underline'>
+              jbsoufron@fwpa-avocats.com
+            </a>{' '}
+            (et, le cas échéant, par courrier postal à FWPA Avocats, 18 rue des Pyramides, 75001
+            Paris, France).
+          </p>
         </div>
         <div>
           <h2 className='mb-4'>5. Limitation de responsabilité</h2>
@@ -64,27 +74,26 @@ export default function MentionsLegales() {
             sont fournies à titre indicatif.
           </p>
           <p>
-            Éclaireur Public ne peut garantir l’exactitude, la complétude ou l’actualité des données
-            mises en ligne et décline toute responsabilité en cas d’erreur ou d’omission.
+            Éclaireur Public ne peut garantir l'exactitude, la complétude ou l'actualité des données
+            mises en ligne et décline toute responsabilité en cas d'erreur ou d'omission.
           </p>
           <p>
-            {' '}
-            L’association Anticor ne pourra être tenue responsable de tout dommage direct ou
-            indirect résultant de l’utilisation du site.
+            L'association Anticor ne pourra être tenue responsable de tout dommage direct ou indirect
+            résultant de l'utilisation du site.
           </p>
         </div>
         <div>
           <h2 className='mb-4'>6. Liens externes</h2>
-          <p>Le site peut contenir des liens vers d’autres sites.</p>
+          <p>Le site peut contenir des liens vers d'autres sites.</p>
           <p>
-            Éclaireur Public n’exerce aucun contrôle sur le contenu de ces sites tiers et ne saurait
+            Éclaireur Public n'exerce aucun contrôle sur le contenu de ces sites tiers et ne saurait
             être tenu responsable de leurs pratiques ou de leurs informations.
           </p>
         </div>
         <div>
           <h2 className='mb-4'>7. Modification des mentions légales</h2>
           <p>
-            Les présentes mentions légales peuvent être modifiées à tout moment pour s’adapter aux
+            Les présentes mentions légales peuvent être modifiées à tout moment pour s'adapter aux
             évolutions législatives ou techniques.
           </p>
           <p>Nous vous invitons à les consulter régulièrement.</p>


### PR DESCRIPTION
## Summary

Replace all placeholder text on the `/legal` page with the actual legal information.

### Changes (`front/app/legal/page.tsx`)

- **Section 1 — Éditeur du site**: ANTICOR (association loi 1901, active depuis le 25/04/2003, fondée en juin 2002). Siège social: 37-39 avenue Ledru Rollin, CS 11237, 75570 Paris Cedex 12. SIREN: 533 081 782. Directrice de la publication: Emma TAILLEFER, Présidente.
- **Section 2 — Hébergeur**: Clever Cloud SAS, 4 rue Voltaire, 44000 Nantes, France. Tél: 02 85 52 07 69.
- **Section 4 — Données personnelles**: DPO contact — jbsoufron@fwpa-avocats.com (FWPA Avocats, 18 rue des Pyramides, 75001 Paris). The email is rendered as a clickable `mailto:` link.
- **Sections 3, 5, 6, 7**: unchanged in substance (only formatting adjustments).

### Before / After

Previously, the page contained `[à compléter]`, `[Adresse complète]`, `[Nom de l'hébergeur]`, `[adresse e-mail de contact]` etc. — all now replaced with real information.

cc @jb-delafosse @m4xim1nus

Made with [Cursor](https://cursor.com)