### PR TITLE
chore: remove Transparency Fr references from benevoles page

### DIFF
--- a/front/app/(a-propos)/benevoles/page.tsx
+++ b/front/app/(a-propos)/benevoles/page.tsx
@@ -52,15 +52,13 @@ export default function Remerciement() {
                 <p>Thomas Pedot</p>
                 <p>Tony Chho</p>
               </div>
-              <h3>Côté Anticor & Transparency Fr</h3>
+              <h3>Côté Anticor</h3>
               <div>
                 <p>Cyrille Brun</p>
                 <p>Emma Taillefer</p>
-                <p>Kévin Gernier</p>
                 <p>Marc Adrai</p>
                 <p>Max Lévy</p>
                 <p>Ronan Sy</p>
-                <p>Samuel Boissaye</p>
               </div>
             </div>
             <div className='space-y-8'>


### PR DESCRIPTION
## Summary
- Remove "& Transparency Fr" from the "Côté Anticor & Transparency Fr" section heading → now reads "Côté Anticor"
- Remove Kévin Gernier and Samuel Boissaye from the contributors list
- Consistent with the broader removal of Transparency International references from the website (PRs #499, #500)

## Test plan
- [ ] Open `/benevoles` and verify the section heading reads "Côté Anticor"
- [ ] Verify Kévin Gernier and Samuel Boissaye no longer appear
- [ ] Verify all other names are still listed correctly

cc @jb-delafosse @m4xim1nus

Made with [Cursor](https://cursor.com)