### PR TITLE
fix: await SMTP send to prevent emails from being silently dropped

### DIFF
--- a/front/utils/emails/send-email.ts
+++ b/front/utils/emails/send-email.ts
@@ -21,9 +21,10 @@ export async function sendEmail(data: FormData) {
 
 export async function trySendMail(mailOptions: Mail.Options) {
   try {
-    sendMailPromise(mailOptions);
+    await sendMailPromise(mailOptions);
     return NextResponse.json({ message: 'Email sent' });
   } catch (err) {
+    console.error('[send-email] SMTP error:', err);
     return NextResponse.json({ error: err }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

- **Critical bug fix**: `sendMailPromise()` was called without `await` in `trySendMail()`, causing the Next.js serverless function to return the HTTP response and terminate before nodemailer completed the SMTP handshake. Emails were never actually delivered despite the API responding with `200 OK`.
- Adds `console.error` logging on SMTP failures so issues are visible in Clever Cloud production logs.

## Context

This bug existed before PR #507 and was identified during its review, but #507 was merged before the fix could land. This is a standalone hotfix targeting `main`.

## Changes

One line change in `front/utils/emails/send-email.ts`:

```diff
- sendMailPromise(mailOptions);
+ await sendMailPromise(mailOptions);
```

## Test plan

- [ ] Deploy to staging/production
- [ ] Test the interpellation flow end-to-end on https://www.eclaireurpublic.fr/interpeller/{siren}/step3
- [ ] Verify the confirmation email is actually received
- [ ] Verify that SMTP errors are now properly returned as HTTP 500 (instead of silent success)


Made with [Cursor](https://cursor.com)