### PR TITLE
fix: robust email error handling and env var validation

### DIFF
--- a/front/app/api/interpellate/confirm/route.ts
+++ b/front/app/api/interpellate/confirm/route.ts
@@ -13,9 +13,7 @@ export async function GET(request: Request) {
   const communityName = searchParams.get('communityName') ?? '';
   const firstname = searchParams.get('firstname') ?? '';
   const lastname = searchParams.get('lastname') ?? '';
-  // mail en CC 
   const email = searchParams.get('email') ?? '';
-  // Mails à interpeller
   const emails = searchParams.get('emails') ?? '';
   const isCC = searchParams.get('isCC') === 'true';
 
@@ -34,7 +32,13 @@ export async function GET(request: Request) {
     html: confirmInterpellateHtml,
   };
 
-  await trySendMail(mailOptions);
+  const result = await trySendMail(mailOptions);
+
+  if (result.status !== 200) {
+    const body = await result.json().catch(() => ({ error: 'unknown' }));
+    console.error('[interpellate/confirm] Failed to send interpellation email:', body.error);
+    redirect(`/interpeller/${siren}/step3?error=send_failed`);
+  }
 
   redirect(`/interpeller/${siren}/step4`);
 }

--- a/front/app/api/interpellate/route.ts
+++ b/front/app/api/interpellate/route.ts
@@ -45,7 +45,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ errors: zodErrors });
   }
 
-  const confirmUrl = new URL('api/interpellate/confirm', process.env.NEXT_PUBLIC_BASE_URL);
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  if (!baseUrl) {
+    console.error('[interpellate] NEXT_PUBLIC_BASE_URL is not set');
+    return NextResponse.json(
+      { error: 'Server misconfiguration: NEXT_PUBLIC_BASE_URL is not set' },
+      { status: 500 },
+    );
+  }
+
+  const confirmUrl = new URL('api/interpellate/confirm', baseUrl);
   const params = new URLSearchParams();
   params.append('siren', siren ?? '');
   params.append('isCC', isCC !== undefined ? isCC.toString() : 'false');
@@ -56,6 +65,7 @@ export async function POST(request: Request) {
   params.append('communityType', communityType ?? '');
   params.append('communityName', communityName ?? '');
   confirmUrl.search = params.toString();
+
   const confirmInterpellateHtml = renderEmailTemplate('confirm-interpellate', {
     firstname: firstname ?? '',
     link: confirmUrl.toString(),

--- a/front/components/Interpellate/InterpellateForm.tsx
+++ b/front/components/Interpellate/InterpellateForm.tsx
@@ -98,7 +98,10 @@ export default function InterpellateForm({
   const onSubmit = async (data: FormSchema) => {
     const response = await postInterpellate(data);
     if (!response.ok) {
-      alert('Submitting form failed!');
+      const body = await response.json().catch(() => null);
+      const detail = body?.error ?? `HTTP ${response.status}`;
+      console.error('[InterpellateForm] submission failed:', detail);
+      alert(`Échec de l'envoi : ${detail}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

Follows up on PR #511 (`await` fix). Now that SMTP errors are properly caught, this PR adds diagnostics so the **actual error is visible** instead of a generic "Submitting form failed!".

## Changes

### `send-email.ts`
- Validates `MY_EMAIL` and `MY_PASSWORD` **before** attempting SMTP connection
- Error message explicitly states which variable is missing (e.g. `SMTP credentials missing: MY_EMAIL=MISSING`)
- Simplified: removed the intermediate `sendMailPromise` wrapper, uses `transport.sendMail()` directly
- Returns the actual error string in the 500 JSON response

### `api/interpellate/route.ts`
- Validates `NEXT_PUBLIC_BASE_URL` before calling `new URL()` (would crash with "Invalid URL" otherwise)
- Returns a clear 500 error if the env var is missing

### `api/interpellate/confirm/route.ts`
- **Bug fix**: previously ignored the result of `trySendMail()` and always redirected to step4, even if the email failed
- Now checks the result and redirects back to step3 on failure

### `InterpellateForm.tsx`
- Reads the actual error from the API response body
- Shows it to the user: `"Échec de l'envoi : <actual error>"` instead of `"Submitting form failed!"`

## Test plan

- [ ] Verify `MY_EMAIL`, `MY_PASSWORD`, and `NEXT_PUBLIC_BASE_URL` are set on Clever Cloud
- [ ] Deploy and test interpellation on https://www.eclaireurpublic.fr/interpeller/{siren}/step3
- [ ] If env vars are missing, confirm the alert shows which one
- [ ] If SMTP fails, confirm the actual SMTP error appears in the alert
- [ ] On success, confirm the confirmation email is received


Made with [Cursor](https://cursor.com)