### PR TITLE
feat: enrichir page Le Projet avec liens internes et CTAs

### DIFF
--- a/front/app/(a-propos)/le-projet/page.tsx
+++ b/front/app/(a-propos)/le-projet/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 import { SectionHeader } from '#app/components/SectionHeader';
+import { BarChart2, ChevronRight, MessageSquare } from 'lucide-react';
 
 export const metadata: Metadata = {
   title: 'Le Projet',
@@ -15,13 +17,20 @@ export default function LeProjet() {
         <div>
           <h2 className='mb-4'>Pourquoi ce projet&nbsp;?</h2>
           <p className='mb-4'>
-            La loi pour une République numérique de 2016 promettait d'apporter transparence et
-            accessibilité des données publiques via leur mise à disposition numérique.
+            La{' '}
+            <Link href='/cadre-reglementaire' className='underline'>
+              loi pour une République numérique de 2016
+            </Link>{' '}
+            promettait d'apporter transparence et accessibilité des données publiques via leur mise
+            à disposition numérique.
           </p>
           <p>
             En 2025, force est de constater que l'ouverture et la publication de ces données ne sont
-            que très partielles. Nos analyses montrent que la grande majorité des collectivités ne
-            publient pas leurs subventions.
+            que très partielles. Nos analyses montrent que la grande majorité des collectivités{' '}
+            <Link href='/perspectives' className='underline'>
+              ne publient pas leurs subventions
+            </Link>
+            .
           </p>
         </div>
         <div>
@@ -35,10 +44,21 @@ export default function LeProjet() {
             La visualisation de données (cartographies, graphiques en bâtons, treemap) est le mode
             privilégié pour rendre ce diagnostic le plus lisible et accessible au plus grand nombre.
           </p>
-          <p>
-            Un indice de transparence a été élaboré afin de pouvoir comparer les collectivités de
-            même nature et de même taille démographique.
+          <p className='mb-6'>
+            <Link href='/methodologie' className='underline'>
+              Un indice de transparence a été élaboré
+            </Link>{' '}
+            afin de pouvoir comparer les collectivités de même nature et de même taille
+            démographique.
           </p>
+          <Link
+            href='/perspectives'
+            className='inline-flex items-center gap-2 rounded-br-xl rounded-tl-xl bg-primary px-5 py-3 font-semibold text-white'
+          >
+            <BarChart2 className='h-4 w-4' />
+            Explorer les données
+            <ChevronRight className='h-4 w-4' />
+          </Link>
         </div>
         <div>
           <h2 className='mb-4'>Pourquoi un diagnostic&nbsp;?</h2>
@@ -47,12 +67,16 @@ export default function LeProjet() {
             subventionnées&nbsp;? Quels sont les marchés publics en cours&nbsp;? Telles sont les
             questions que tout citoyen se pose légitimement et auxquelles le projet Eclaireur Public
             aimerait être en mesure d'apporter une réponse. Et si tel n'est pas le cas, donner les
-            moyens de questionner nos élus locaux.
+            moyens de{' '}
+            <Link href='/interpeller' className='underline'>
+              questionner nos élus locaux
+            </Link>
+            .
           </p>
         </div>
         <div>
           <h2 className='mb-4'>Mais quel intérêt vraiment&nbsp;?</h2>
-          <p>
+          <p className='mb-6'>
             Le citoyen lambda déclare ses revenus, s'acquitte des ses impôts, se conforme à la
             loi... pour "faire société". Aucune raison ne justifie que nos collectivités ne se
             conforment pas à leurs obligations légales d'information. La désaffection des citoyens
@@ -64,6 +88,14 @@ export default function LeProjet() {
             politique et la lutte contre la corruption nécessitent une plus grande transparence des
             politiques publiques, et donc des données publiques.
           </p>
+          <Link
+            href='/interpeller'
+            className='inline-flex items-center gap-2 rounded-br-xl rounded-tl-xl bg-brand-3 px-5 py-3 font-semibold'
+          >
+            <MessageSquare className='h-4 w-4' />
+            Interpeller vos élus
+            <ChevronRight className='h-4 w-4' />
+          </Link>
         </div>
       </article>
     </main>


### PR DESCRIPTION
## Summary

- 4 liens inline ajoutés sans modifier le texte statique validé :
  - "loi pour une République numérique de 2016" → `/cadre-reglementaire`
  - "ne publient pas leurs subventions" → `/perspectives`
  - "Un indice de transparence a été élaboré" → `/methodologie`
  - "questionner nos élus locaux" → `/interpeller`
- CTA **"Explorer les données"** (bouton bleu `bg-primary`) après la section "Un diagnostic de la transparence publique" → `/perspectives`
- CTA **"Interpeller vos élus"** (bouton vert `bg-brand-3`) en fin de page → `/interpeller`
- Style des CTAs : `rounded-br-xl rounded-tl-xl` + icône Lucide, cohérent avec `ProjectDescription.tsx` et `CtaCard`

## Test plan

- [ ] Vérifier `/le-projet` : les 4 liens inline sont cliquables et pointent vers les bonnes pages
- [ ] CTA "Explorer les données" → redirige vers `/perspectives`
- [ ] CTA "Interpeller vos élus" → redirige vers `/interpeller`
- [ ] Vérifier la cohérence visuelle avec le reste du site (couleurs, coins arrondis)
- [ ] Vérifier sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)